### PR TITLE
feat: M6-003 SwiftUI에서 유지되는 WKWebView 최소 실행 경로

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,9 +1,9 @@
 # KLAS+ KMP 마이그레이션 작업 현황
 
-- 기준일: 2026-08-06
+- 기준일: 2026-08-07
 - 현재 단계: **Android 마이그레이션 완료, iOS 기본 제품 경로(M6) 진행 중**
 - Android 상태: KMP 공통 코어, Compose UI, WebView 브리지, 네이티브 기능의 P0/P1 패리티 완료
-- iOS 상태: 프로젝트 골격과 최소 지원 정책만 확정. 실제 제품 경로와 플랫폼 기능은 미구현
+- iOS 상태: 툴체인·framework·WKWebView holder smoke 완료. cookie·bridge·인증·제품 경로는 미구현
 
 
 ## 개요
@@ -15,7 +15,7 @@
 | M3 공통 코어 | **완료(9/9)** | 인증·세션·API·보안 저장소·앱 잠금 공통화 및 Android 연결 완료 |
 | M4 Android Web/Compose | 진행 중(7/8) | Android 화면 전환 완료. legacy 자산 정리만 남음 |
 | M5 Android 기능 패리티 | **완료(7/7)** | QR·잠금·PIP·위젯·파일·테마 및 전체 Android 회귀 통과 |
-| M6 iOS 기본 경로 | 진행 중(4/11) | Web adapter 준비 완료. 다음: M6-003 WKWebView 최소 실행 경로 → M6-006·007 Native bridge 연결 |
+| M6 iOS 기본 경로 | 진행 중(5/11) | M6-003 WKWebView holder smoke 완료. 다음: M6-006 navigation/cookie → M6-007 Native bridge |
 | M7 iOS 플랫폼 기능 | 미착수(0/7) | M6 기본 경로 이후 진행 |
 
 
@@ -87,11 +87,12 @@
   - Depends on: M6-001
   - 브랜치: `m6-001-002/ios-toolchain-framework`
   - 완료 기준: `iosArm64`·`iosSimulatorArm64` 빌드와 Xcode 링크
-- [ ] **M6-003 (P0, M)** SwiftUI에서 유지되는 WKWebView 최소 실행 경로
+- [x] **M6-003 (P0, M)** SwiftUI에서 유지되는 WKWebView 최소 실행 경로
   - Depends on: M6-002
-  - 작업: `UIViewRepresentable`은 WKWebView를 표시만 하고, 별도 holder가 인스턴스 생성·보존·해제를 소유
-  - 완료 기준: 고정된 앱 Web URL을 로드하고 SwiftUI 재렌더링·화면 재진입에도 WKWebView와 history가 불필요하게 재생성되지 않음
-  - 검증: Simulator에서 첫 로드, 재렌더링, 화면 재진입, 명시적 dispose 시 인스턴스와 delegate 수명주기 확인
+  - 브랜치: `m6-003/ios-wkwebview-holder`
+  - `WebViewHolder`가 생성·보존·dispose를 소유하고 `WebViewContainer`는 표시만 담당
+  - App `@StateObject`로 holder 수명 분리. smoke URL은 Shared `KlasUrls.KLAS_PLUS_BASE` + `/feed`
+  - 검증: Simulator에서 고정 URL 로드, 재렌더·재진입 시 인스턴스 유지, 명시적 dispose
 - [x] **M6-004 (P0, M)** Next.js bridge contract test 작성
   - 대상: 별도 `kw-klas-plus-webview` 저장소
   - 검증: Bridge v1 request/response, timeout, unknown-method legacy retry, 미지원 브라우저 동작

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -1,14 +1,68 @@
 import SwiftUI
 
 struct ContentView: View {
+    @ObservedObject var holder: WebViewHolder
+    @State private var tick = 0
+    @State private var path = NavigationPath()
+
     var body: some View {
-        ProgressView()
-            .accessibilityLabel("KLAS+")
+        NavigationStack(path: $path) {
+            ZStack(alignment: .bottom) {
+                if holder.isDisposed {
+                    Text("WebView disposed")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .accessibilityLabel("KLAS+")
+                } else {
+                    WebViewContainer(webView: holder.webView)
+                        .ignoresSafeArea(edges: .bottom)
+                        .accessibilityLabel("KLAS+")
+                }
+
+                #if DEBUG
+                smokeControls
+                #endif
+            }
+            .navigationTitle("KLAS+")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(for: String.self) { _ in
+                Text("Placeholder — pop to verify WebView identity")
+                    .navigationTitle("Re-entry")
+            }
+            .onAppear {
+                holder.loadSmokeURLIfNeeded()
+            }
+        }
     }
+
+    #if DEBUG
+    private var smokeControls: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("creationID: \(holder.creationID.uuidString)")
+                .font(.caption2.monospaced())
+            Text("tick: \(tick)")
+                .font(.caption2)
+            if let url = holder.lastFinishedURL {
+                Text("finished: \(url)")
+                    .font(.caption2)
+                    .lineLimit(1)
+            }
+            HStack {
+                Button("Rerender") { tick += 1 }
+                Button("Push") { path.append("placeholder") }
+                Button("Dispose WebView") { holder.dispose() }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+        .padding(8)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.ultraThinMaterial)
+    }
+    #endif
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
+        ContentView(holder: WebViewHolder())
     }
 }

--- a/iosApp/iosApp/WebViewContainer.swift
+++ b/iosApp/iosApp/WebViewContainer.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import WebKit
+
+// 이미 생성된 WKWebView를 SwiftUI에 표시
+struct WebViewContainer: UIViewRepresentable {
+    let webView: WKWebView
+
+    func makeUIView(context: Context) -> WKWebView {
+        webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        // SwiftUI 재렌더링에서 WKWebView를 재생성 하지 않음
+    }
+}

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Shared
+import WebKit
+
+// WKWebView 생성,보존,해제
+final class WebViewHolder: NSObject, ObservableObject {
+    let creationID = UUID()
+
+    @Published private(set) var isDisposed = false
+    @Published private(set) var lastFinishedURL: String?
+
+    private var didLoadInitialURL = false
+    private var _webView: WKWebView?
+    private lazy var navigationRelay = NavigationRelay(owner: self)
+
+    var webView: WKWebView {
+        if let existing = _webView {
+            return existing
+        }
+        precondition(!isDisposed, "disposed WebViewHolder는 WKWebView를 다시 생성하지 않는다")
+        let configuration = WKWebViewConfiguration()
+        let created = WKWebView(frame: .zero, configuration: configuration)
+        created.navigationDelegate = navigationRelay
+        _webView = created
+        return created
+    }
+
+    // Android Home과 동일한 베이스 URL. yearHakgi는 M6-008 이후 연결
+    // Shared KlasUrls.KLAS_PLUS_BASE와 동기화
+    static var smokeURL: URL {
+        let base = KlasUrls.shared.KLAS_PLUS_BASE
+        return URL(string: base + "/feed")!
+    }
+
+    func loadSmokeURLIfNeeded() {
+        guard !isDisposed, !didLoadInitialURL else { return }
+        didLoadInitialURL = true
+        webView.load(URLRequest(url: Self.smokeURL))
+    }
+
+    func dispose() {
+        guard !isDisposed else { return }
+        isDisposed = true
+        guard let view = _webView else { return }
+        view.stopLoading()
+        view.navigationDelegate = nil
+        view.uiDelegate = nil
+        view.removeFromSuperview()
+        _webView = nil
+        lastFinishedURL = nil
+    }
+
+    fileprivate func navigationDidFinish(url: String?) {
+        guard !isDisposed else { return }
+        lastFinishedURL = url
+    }
+
+    fileprivate func navigationDidFail() {
+        guard !isDisposed else { return }
+    }
+}
+
+// 로딩 완료만 관찰. back/forward·cookie·외부 URL은 M6-006
+private final class NavigationRelay: NSObject, WKNavigationDelegate {
+    weak var owner: WebViewHolder?
+
+    init(owner: WebViewHolder) {
+        self.owner = owner
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        owner?.navigationDidFinish(url: webView.url?.absoluteString)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        owner?.navigationDidFail()
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        owner?.navigationDidFail()
+    }
+}

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -2,9 +2,11 @@ import SwiftUI
 
 @main
 struct iOSApp: App {
+    @StateObject private var webViewHolder = WebViewHolder()
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(holder: webViewHolder)
         }
     }
 }


### PR DESCRIPTION
## Summary

iOS에서는 WebViewHolder가 WKWebView의 생성·유지·해제를 맡고, WebViewContainer(UIViewRepresentable)는 화면에 붙이기만 합니다. Holder는 App의 @StateObject로 두어 화면 재렌더와 수명을 분리했고, 임시로 WebView 최초 진입 시 KlasUrls.KLAS_PLUS_BASE + /feed를 로드하도록 했습니다.

## Verification

https://github.com/user-attachments/assets/81d4e5b1-0d8a-4bf5-a0eb-a1b257f39e42

- `/feed` URL 로드 (인증 전이라 Play Store로 리다이렉트됨)
- Rerender: SwiftUI `body`만 다시 그림. `creationID`는 동일
- Push: placeholder로 이동 후 뒤로가기해도 동일 `creationID`의 WebView가 유지됨