### PR TITLE
feat: M6-010 iOS 다운로드, 파일 선택, 외부 이동

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -140,6 +140,8 @@
   - Depends on: M6-009
   - 작업: WKDownload/URLSession, document/photo picker, share sheet, `UIApplication.open`을 공통 요청·URL 정책에 연결
   - 완료 기준: cookie가 필요한 다운로드, MIME·파일명, 단일/다중 선택, 취소, mailto/tel/https와 악성 scheme 거부
+  - 검증: `IosFilePortsTests` — 다운로드 single-flight, 중복 요청 거부, 취소 완료 전 재진입 방지, cookie·MIME·파일명·파일 선택·외부 URL 정책
+  - 검증: `FileTransferPolicyTest` — `inline`/`attachment` disposition type, 표시 가능 MIME, 저장 대상 문서 MIME 분기
 - [ ] **M6-011 (P1, M)** WKWebView 컨테이너의 iOS UI 환경 대응
   - Depends on: M6-009
   - 작업: SwiftUI theme, safe area, 키보드·viewport, iPhone/iPad 회전과 Dynamic Type/VoiceOver focus 처리

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,20 +1,20 @@
 # KLAS+ KMP 마이그레이션 작업 현황
 
-- 기준일: 2026-08-07
+- 기준일: 2026-08-23
 - 현재 단계: **Android 마이그레이션 완료, iOS 기본 제품 경로(M6) 진행 중**
 - Android 상태: KMP 공통 코어, Compose UI, WebView 브리지, 네이티브 기능의 P0/P1 패리티 완료
-- iOS 상태: 툴체인·framework·WKWebView navigation/cookie·Native bridge·인증/세션·화면별 제품 경로·다운로드/파일 완료. 다음: UI 환경
+- iOS 상태: 툴체인·framework·WKWebView navigation/cookie·Native bridge·인증/세션·화면별 제품 경로·다운로드/외부 이동 완료. 파일 업로드는 실계정 검증 남음. 다음: UI 환경
 
 ## 개요
 
 | Milestone              | 상태          | 결과 / 다음 게이트                               |
-| ---------------------- | ----------- | ----------------------------------------- |
+| ---------------------- |-------------| ----------------------------------------- |
 | M1 계약 고정               | **완료(6/6)** | Android 인증·브리지·저장소·플랫폼 계약 고정 완료           |
 | M2 KMP/Android 기반      | **완료(6/6)** | 공통 모듈과 Android source set 경계 정렬 완료        |
 | M3 공통 코어               | **완료(9/9)** | 인증·세션·API·보안 저장소·앱 잠금 공통화 및 Android 연결 완료 |
 | M4 Android Web/Compose | 진행 중(7/8)   | Android 화면 전환 완료. legacy 자산 정리만 남음        |
 | M5 Android 기능 패리티      | **완료(7/7)** | QR·잠금·PIP·위젯·파일·테마 및 전체 Android 회귀 통과     |
-| M6 iOS 기본 경로           | 진행 중(10/11) | M6-010 다운로드·파일 완료. 다음: M6-011 UI 환경     |
+| M6 iOS 기본 경로           | 진행 중(9/11)  | M6-010 다운로드·외부 이동 완료. 파일 업로드 실계정 검증 남음. 다음: M6-011 UI 환경 |
 | M7 iOS 플랫폼 기능          | 미착수(0/7)    | M6 기본 경로 이후 진행                            |
 
 ### M1 — 기존 계약 고정
@@ -72,7 +72,7 @@
 
 ### M6 — iOS 기본 기능 구현
 
-진행 순서: `M6-003` WKWebView smoke → `M6-006` navigation/cookie → `M6-007` Native bridge → `M6-008` 인증/세션 → `M6-009` 화면별 제품 경로 → `M6-010` 다운로드·파일. 완료된 `M6-004`·`M6-005`는 Web 측 선행 계약이다. `M6-010`까지 완료.
+진행 순서: `M6-003` WKWebView smoke → `M6-006` navigation/cookie → `M6-007` Native bridge → `M6-008` 인증/세션 → `M6-009` 화면별 제품 경로 → `M6-010` 다운로드·파일. 완료된 `M6-004`·`M6-005`는 Web 측 선행 계약이다. `M6-010` 다운로드·외부 이동은 완료, 파일 업로드 실계정 검증은 후속.
 
 - [x] **M6-001 (P0, M)** iOS 툴체인과 최소 지원 환경 고정
   - 브랜치: `m6-001-002/ios-toolchain-framework`
@@ -129,19 +129,11 @@
   - 작업: Home·Lecture·Board·LecturePlan·Link·Settings command 중 해당 화면에 필요한 navigation/modal/reload/callback 연결
   - 완료 기준: F-007~F-016 P0 경로에서 `KlasNativeBridge.*` 호출과 Native → Web callback이 Android와 동일한 결과를 생성
   - 검증: 앱 Web + 신 iOS 조합의 탭·back·게시판·강의·과제 링크·학기 선택·modal 회귀
-  - 증거:
-    - `./gradlew :shared:iosSimulatorArm64Test --tests 'com.icecream.kwklasplus.core.bridge.IosLegacyBridgeCommandHandlerTest' --tests 'com.icecream.kwklasplus.core.web.ProductWebUrlsTest' --tests 'com.icecream.kwklasplus.core.web.IosWebCallbacksTest'`
-    - `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test`
-    - `IosLegacyBridgeCommandHandlerTest`: changeTab/completePageLoad/openLecture, QR stub Success, board path, settings lock JSON, board completePageLoad
-    - `IosHomeHostTests`: Home 탭 URL, receivedData 2/3/4인자, `receiveToken` 주입, `closeWebViewBottomSheet` 스크립트, 제품 UA `iOSApp_v1`, 세션 없이 학기·옵션·날짜 picker와 Settings push, 강의/게시판/과제는 세션 없으면 push하지 않음
-    - `IosHomeHostTests`: bootstrap 실패 후 재시도 성공 시 Home holder 부착과 `.ready` 전환
-    - 수동: 실계정 로그인 후 탭·강의·게시판·과제·학기 picker·modal 확인 (QR/영상/도서관/잠금은 M7 stub 안내). 웹 `bottomNav.js` iOS UA 분기는 Web 저장소 배포 후 하단 탭이 표시됨
-- [x] **M6-010 (P1, L)** WKWebView 다운로드·파일 선택·외부 이동
+- [ ] **M6-010 (P1, L)** WKWebView 다운로드·파일 선택·외부 이동
   - Depends on: M6-009
   - 작업: WKDownload/URLSession, document/photo picker, share sheet, `UIApplication.open`을 공통 요청·URL 정책에 연결
   - 완료 기준: cookie가 필요한 다운로드, MIME·파일명, 단일/다중 선택, 취소, mailto/tel/https와 악성 scheme 거부
-  - 검증: `IosFilePortsTests` — 다운로드 single-flight, 중복 요청 거부, 취소 완료 전 재진입 방지, cookie·MIME·파일명·파일 선택·외부 URL 정책
-  - 검증: `FileTransferPolicyTest` — `inline`/`attachment` disposition type, 표시 가능 MIME, 저장 대상 문서 MIME 분기
+  - 남은 일: 파일 업로드(`UIDocumentPicker`)는 계약 테스트만 통과. 실계정 KLAS 업로드 경로 검증 후 완료 처리
 - [ ] **M6-011 (P1, M)** WKWebView 컨테이너의 iOS UI 환경 대응
   - Depends on: M6-009
   - 작업: SwiftUI theme, safe area, 키보드·viewport, iPhone/iPad 회전과 Dynamic Type/VoiceOver focus 처리

--- a/TASKS.md
+++ b/TASKS.md
@@ -3,7 +3,7 @@
 - 기준일: 2026-08-07
 - 현재 단계: **Android 마이그레이션 완료, iOS 기본 제품 경로(M6) 진행 중**
 - Android 상태: KMP 공통 코어, Compose UI, WebView 브리지, 네이티브 기능의 P0/P1 패리티 완료
-- iOS 상태: 툴체인·framework·WKWebView navigation/cookie·Native bridge·인증/세션·화면별 제품 경로 완료. 다음: 다운로드/파일
+- iOS 상태: 툴체인·framework·WKWebView navigation/cookie·Native bridge·인증/세션·화면별 제품 경로·다운로드/파일 완료. 다음: UI 환경
 
 ## 개요
 
@@ -14,7 +14,7 @@
 | M3 공통 코어               | **완료(9/9)** | 인증·세션·API·보안 저장소·앱 잠금 공통화 및 Android 연결 완료 |
 | M4 Android Web/Compose | 진행 중(7/8)   | Android 화면 전환 완료. legacy 자산 정리만 남음        |
 | M5 Android 기능 패리티      | **완료(7/7)** | QR·잠금·PIP·위젯·파일·테마 및 전체 Android 회귀 통과     |
-| M6 iOS 기본 경로           | 진행 중(9/11)  | M6-009 화면별 제품 경로 완료. 다음: M6-010 다운로드·파일 |
+| M6 iOS 기본 경로           | 진행 중(10/11) | M6-010 다운로드·파일 완료. 다음: M6-011 UI 환경     |
 | M7 iOS 플랫폼 기능          | 미착수(0/7)    | M6 기본 경로 이후 진행                            |
 
 ### M1 — 기존 계약 고정
@@ -72,7 +72,7 @@
 
 ### M6 — iOS 기본 기능 구현
 
-진행 순서: `M6-003` WKWebView smoke → `M6-006` navigation/cookie → `M6-007` Native bridge → `M6-008` 인증/세션 → `M6-009` 화면별 제품 경로. 완료된 `M6-004`·`M6-005`는 Web 측 선행 계약이다. `M6-009`까지 완료.
+진행 순서: `M6-003` WKWebView smoke → `M6-006` navigation/cookie → `M6-007` Native bridge → `M6-008` 인증/세션 → `M6-009` 화면별 제품 경로 → `M6-010` 다운로드·파일. 완료된 `M6-004`·`M6-005`는 Web 측 선행 계약이다. `M6-010`까지 완료.
 
 - [x] **M6-001 (P0, M)** iOS 툴체인과 최소 지원 환경 고정
   - 브랜치: `m6-001-002/ios-toolchain-framework`
@@ -136,7 +136,7 @@
     - `IosHomeHostTests`: Home 탭 URL, receivedData 2/3/4인자, `receiveToken` 주입, `closeWebViewBottomSheet` 스크립트, 제품 UA `iOSApp_v1`, 세션 없이 학기·옵션·날짜 picker와 Settings push, 강의/게시판/과제는 세션 없으면 push하지 않음
     - `IosHomeHostTests`: bootstrap 실패 후 재시도 성공 시 Home holder 부착과 `.ready` 전환
     - 수동: 실계정 로그인 후 탭·강의·게시판·과제·학기 picker·modal 확인 (QR/영상/도서관/잠금은 M7 stub 안내). 웹 `bottomNav.js` iOS UA 분기는 Web 저장소 배포 후 하단 탭이 표시됨
-- [ ] **M6-010 (P1, L)** WKWebView 다운로드·파일 선택·외부 이동
+- [x] **M6-010 (P1, L)** WKWebView 다운로드·파일 선택·외부 이동
   - Depends on: M6-009
   - 작업: WKDownload/URLSession, document/photo picker, share sheet, `UIApplication.open`을 공통 요청·URL 정책에 연결
   - 완료 기준: cookie가 필요한 다운로드, MIME·파일명, 단일/다중 선택, 취소, mailto/tel/https와 악성 scheme 거부

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -28,9 +28,9 @@
 | F-011 | 성적/석차/장학/KLAS AI | WebSurface | WKWebView surface | P1 | Parity | iOS M6-009: Home `openPage` → Link 화면. sheet flag + back 시 `closeWebViewBottomSheet` |
 | F-012 | 강의 홈 | Compose + WebView | SwiftUI + WKWebView | P0 | Parity | iOS M6-009: dual WKWebView, `receivedData` 3인자, `evaluteKLASScript`. QR/영상은 M7 stub |
 | F-013 | 강의계획서 | typed Web route | typed Web route | P1 | Parity | iOS M6-009: LecturePlan surface + `receivedData` 2인자 |
-| F-014 | 게시판 목록/상세 | Web route + file ports | 동일 | P0 | Parity | iOS M6-009: Board surface + `receivedData` 4인자. 첨부/다운로드는 M6-010 |
+| F-014 | 게시판 목록/상세 | Web route + file ports | 동일 | P0 | Parity | iOS M6-009: Board surface + `receivedData` 4인자 |
 | F-015 | 과제/퀴즈/시험 링크 | KLAS Web route | 동일 | P0 | Parity | iOS M6-009: Task 화면(브리지 없음) localStorage bootstrap. 영상 URL은 M7 stub |
-| F-016 | 일반 링크 | typed navigation + Android adapter | iOS navigation adapter | P1 | Parity | iOS M6-009: `AppRouteFactory` + Link host. 파일 선택은 M6-010 |
+| F-016 | 일반 링크 | typed navigation + Android adapter | iOS navigation adapter | P1 | Parity | iOS M6-009: `AppRouteFactory` + Link host |
 | F-017 | 온라인 강의 재생 | Android player/PIP host | iOS player host | P0 | Parity | 재생·seek·speed·진도 포함 |
 | F-018 | PIP | Android native | AVKit/WK media | P1 | Parity | remote action·상태 복구 포함 |
 | F-019 | QR 출석 | Android scanner port | AVFoundation/VisionKit port | P0 | Parity | 성공·실패·취소·중복 실행 포함 |

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -39,7 +39,7 @@
 | F-022 | 앱 잠금 PIN | 공통 policy + Android lifecycle | 공통 policy + iOS scene phase | P0 | Parity | 업그레이드·위젯 예외 포함 |
 | F-023 | 생체인식 | Android biometric port | LocalAuthentication port | P0 | Parity | 성공·취소·미등록·미지원 포함 |
 | F-024 | 설정/테마/버전 | 공통 Web/Compose + settings | 동일 | P1 | Parity | 재시작 persistence 포함. iOS `KlasTheme` 토큰은 Android `values`/`values-night` light·dark 쌍 |
-| F-025 | 다운로드 | Android DownloadManager/SAF | URLSession/files/share | P1 | Parity | cookie·MIME·filename·취소 포함 |
+| F-025 | 다운로드 | Android DownloadManager/SAF | URLSession/files/share | P1 | Parity | cookie·MIME·filename·취소 포함. `inline` 파일명은 표시 가능 MIME이면 렌더링하고 `attachment`만 강제 다운로드. iOS는 single-flight로 중복 요청과 취소 완료 전 재진입을 거부 |
 | F-026 | 파일 선택/업로드 | Activity Result adapter | document/photo picker | P1 | Parity | 단일·다중·MIME·취소 포함 |
 | F-027 | 외부 링크/mailto | allowlist + Android Intent | allowlist + UIApplication | P1 | Parity | 악성 URL 거부 포함 |
 | F-028 | 햅틱 | semantic haptic adapter | UIKit feedback adapter | P2 | Parity | legacy 14개 이름 보존 |

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -40,7 +40,7 @@
 | F-023 | 생체인식 | Android biometric port | LocalAuthentication port | P0 | Parity | 성공·취소·미등록·미지원 포함 |
 | F-024 | 설정/테마/버전 | 공통 Web/Compose + settings | 동일 | P1 | Parity | 재시작 persistence 포함. iOS `KlasTheme` 토큰은 Android `values`/`values-night` light·dark 쌍 |
 | F-025 | 다운로드 | Android DownloadManager/SAF | URLSession/files/share | P1 | Parity | cookie·MIME·filename·취소 포함. `inline` 파일명은 표시 가능 MIME이면 렌더링하고 `attachment`만 강제 다운로드. iOS는 single-flight로 중복 요청과 취소 완료 전 재진입을 거부 |
-| F-026 | 파일 선택/업로드 | Activity Result adapter | document/photo picker | P1 | Parity | 단일·다중·MIME·취소 포함 |
+| F-026 | 파일 선택/업로드 | Activity Result adapter | document/photo picker | P1 | Parity | 단일·다중·MIME·취소 포함. iOS M6-010: `UIDocumentPicker`와 계약 테스트는 있음. 실계정 업로드 검증은 후속 |
 | F-027 | 외부 링크/mailto | allowlist + Android Intent | allowlist + UIApplication | P1 | Parity | 악성 URL 거부 포함 |
 | F-028 | 햅틱 | semantic haptic adapter | UIKit feedback adapter | P2 | Parity | legacy 14개 이름 보존 |
 | F-029 | Android 인앱 업데이트 | Play Core legacy 경로 유지 | Approved difference | P2 | Parity | Android 전용 기능 |

--- a/iosApp/iosApp/AuthSessionController.swift
+++ b/iosApp/iosApp/AuthSessionController.swift
@@ -116,7 +116,7 @@ final class AuthSessionController: ObservableObject {
     }
 
     func openExternal(_ url: URL) {
-        UIApplication.shared.open(url)
+        _ = IosExternalNavigator.companion.system().openValidated(rawValue: url.absoluteString)
     }
 
     /// 로그인 화면 URL 분기: KLAS 복구/등록은 인앱 WebView, 그 외(동의 블로그 등)는 외부 브라우저

--- a/iosApp/iosApp/DownloadOverlay.swift
+++ b/iosApp/iosApp/DownloadOverlay.swift
@@ -1,0 +1,60 @@
+import Shared
+import SwiftUI
+
+struct DownloadProgressState: Equatable {
+    var fileName: String
+    var fraction: Double
+}
+
+struct DownloadProgressOverlay: View {
+    let fileName: String
+    let fraction: Double
+    let onCancel: () -> Void
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.35)
+            VStack(spacing: 16) {
+                Text(fileName)
+                    .font(.headline)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+                if fraction > 0 {
+                    ProgressView(value: min(max(fraction, 0), 1))
+                } else {
+                    ProgressView()
+                }
+                Button("취소", action: onCancel)
+            }
+            .padding(24)
+            .frame(maxWidth: 320)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+        }
+        .accessibilityIdentifier("download_progress_overlay")
+    }
+}
+
+extension View {
+    func webDownloadOverlay(_ holder: WebViewHolder) -> some View {
+        overlay {
+            if let progress = holder.downloadProgress {
+                DownloadProgressOverlay(
+                    fileName: progress.fileName,
+                    fraction: progress.fraction,
+                    onCancel: { holder.cancelDownload() }
+                )
+            }
+        }
+        .alert(
+            "다운로드 실패",
+            isPresented: Binding(
+                get: { holder.downloadErrorMessage != nil },
+                set: { if !$0 { holder.clearDownloadError() } }
+            )
+        ) {
+            Button("확인") { holder.clearDownloadError() }
+        } message: {
+            Text(holder.downloadErrorMessage ?? "")
+        }
+    }
+}

--- a/iosApp/iosApp/HomeCoordinator.swift
+++ b/iosApp/iosApp/HomeCoordinator.swift
@@ -58,7 +58,7 @@ final class HomeCoordinator: ObservableObject {
     private let routeFactory = AppRouteFactory(
         webPolicy: ExternalNavigationPolicy(maximumLength: 2048)
     )
-    private let externalPolicy = ExternalNavigationPolicy(maximumLength: 2048)
+    private let navigator = IosExternalNavigator.companion.system()
     private static let dateTimeFormatter: DateFormatter = {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
@@ -220,10 +220,7 @@ final class HomeCoordinator: ObservableObject {
     }
 
     func openExternal(url: String) {
-        let resolution = externalPolicy.resolve(rawValue: url)
-        if let allowed = resolution as? ExternalNavigationResolutionAllowed {
-            openDestination(allowed.destination)
-        }
+        _ = navigator.openValidated(rawValue: url)
     }
 
     func openBoardList(path: String, title: String, subjectId: String, yearSemester: String) {
@@ -340,9 +337,16 @@ final class HomeCoordinator: ObservableObject {
         }
     }
 
-    func openExternalAppSearch(_ query: String) {
-        let encoded = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
-        if let url = URL(string: "https://apps.apple.com/kr/search?term=\(encoded)") {
+    func openOfficialAppStore() {
+        openAppStore(id: "1510521632")
+    }
+
+    func openLibraryAppStore() {
+        openAppStore(id: "1192646132")
+    }
+
+    private func openAppStore(id: String) {
+        if let url = URL(string: "itms-apps://itunes.apple.com/app/id\(id)") {
             UIApplication.shared.open(url)
         }
         showOptionsMenu = false
@@ -452,23 +456,6 @@ final class HomeCoordinator: ObservableObject {
             handler: IosHomeLegacyBridgeCommandHandler(host: adapter)
         )
         homeHolder = holder
-    }
-
-    private func openDestination(_ destination: ExternalDestination) {
-        let raw: String
-        if let web = destination as? ExternalDestinationWeb {
-            raw = web.url
-        } else if let email = destination as? ExternalDestinationEmail {
-            raw = "mailto:\(email.address)"
-        } else if let tel = destination as? ExternalDestinationTelephone {
-            raw = "tel:\(tel.number)"
-        } else if let platform = destination as? ExternalDestinationPlatformUri {
-            raw = platform.uri
-        } else {
-            return
-        }
-        guard let url = URL(string: raw) else { return }
-        UIApplication.shared.open(url)
     }
 
     static func platformUserAgent() -> String {

--- a/iosApp/iosApp/HomeOverlays.swift
+++ b/iosApp/iosApp/HomeOverlays.swift
@@ -74,10 +74,10 @@ struct HomeOverlayModifier: ViewModifier {
     private var optionsSheet: some View {
         SelectionBottomSheet(options: [
             SelectionOptionRow(title: "광운대학교 공식 앱") {
-                coordinator.openExternalAppSearch("광운대학교")
+                coordinator.openOfficialAppStore()
             },
             SelectionOptionRow(title: "중앙도서관 앱") {
-                coordinator.openExternalAppSearch("광운대학교 도서관")
+                coordinator.openLibraryAppStore()
             },
             SelectionOptionRow(title: "앱 설정") {
                 coordinator.openSettings()

--- a/iosApp/iosApp/HomeView.swift
+++ b/iosApp/iosApp/HomeView.swift
@@ -29,6 +29,7 @@ struct HomeView: View {
         .onReceive(holder.$navigationState) { state in
             coordinator.handleHomeNavigation(state)
         }
+        .webDownloadOverlay(holder)
         .accessibilityIdentifier("home_view")
     }
 }

--- a/iosApp/iosApp/IosFilePicker.swift
+++ b/iosApp/iosApp/IosFilePicker.swift
@@ -1,0 +1,86 @@
+import Shared
+import UniformTypeIdentifiers
+import UIKit
+
+protocol FilePickerPresenting: AnyObject {
+    func present(allowMultiple: Bool, from presenter: UIViewController?, completion: @escaping (FilePickerResult) -> Void)
+}
+
+final class IosFilePicker {
+    private let presenter: FilePickerPresenting
+
+    init(presenter: FilePickerPresenting = SystemFilePickerPresenter()) {
+        self.presenter = presenter
+    }
+
+    func pickForWeb(allowMultiple: Bool, from viewController: UIViewController?, completion: @escaping ([URL]?) -> Void) {
+        presenter.present(allowMultiple: allowMultiple, from: viewController) { result in
+            if let selected = result as? FilePickerResultSelected {
+                completion(selected.references.compactMap(URL.init(string:)))
+            } else {
+                completion(nil)
+            }
+        }
+    }
+}
+
+final class SystemFilePickerPresenter: NSObject, FilePickerPresenting, UIDocumentPickerDelegate {
+    private var completion: ((FilePickerResult) -> Void)?
+
+    func present(
+        allowMultiple: Bool,
+        from presenter: UIViewController?,
+        completion: @escaping (FilePickerResult) -> Void
+    ) {
+        finishPending(FilePickerResultCancelled())
+        self.completion = completion
+        guard let presenter = presenter ?? UIView.klas_keyWindowRootViewController else {
+            finishPending(FilePickerResultFailed(reason: "no_presenter"))
+            return
+        }
+        let picker = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+        picker.allowsMultipleSelection = allowMultiple
+        picker.delegate = self
+        presenter.present(picker, animated: true)
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        controller.dismiss(animated: true)
+        if urls.isEmpty {
+            finishPending(FilePickerResultCancelled())
+        } else {
+            finishPending(FilePickerResultSelected(references: urls.map(\.absoluteString)))
+        }
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        finishPending(FilePickerResultCancelled())
+    }
+
+    private func finishPending(_ result: FilePickerResult) {
+        let completion = completion
+        self.completion = nil
+        completion?(result)
+    }
+}
+
+extension UIView {
+    static var klas_keyWindowRootViewController: UIViewController? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow }?
+            .rootViewController
+    }
+
+    var klas_presentingViewController: UIViewController? {
+        var responder: UIResponder? = self
+        while let current = responder {
+            if let viewController = current as? UIViewController {
+                return viewController
+            }
+            responder = current.next
+        }
+        return Self.klas_keyWindowRootViewController
+    }
+}

--- a/iosApp/iosApp/IosFileTransfer.swift
+++ b/iosApp/iosApp/IosFileTransfer.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Shared
+import WebKit
+
+protocol DownloadCookieProviding {
+    func cookieHeader(for url: URL) async -> String?
+}
+
+struct WKWebsiteCookieProvider: DownloadCookieProviding {
+    let store: WKHTTPCookieStore
+
+    init(store: WKHTTPCookieStore = WKWebsiteDataStore.default().httpCookieStore) {
+        self.store = store
+    }
+
+    func cookieHeader(for url: URL) async -> String? {
+        let cookies: [HTTPCookie] = await withCheckedContinuation { continuation in
+            store.getAllCookies { continuation.resume(returning: $0) }
+        }
+        let matching = cookies.filter { $0.klas_matches(url) }
+        let header = HTTPCookie.requestHeaderFields(with: matching)["Cookie"]
+        return header?.isEmpty == false ? header : nil
+    }
+}
+
+enum IosDownloadFileStore {
+    static var root: URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("klas-downloads", isDirectory: true)
+    }
+
+    static func makeDestination(fileName: String) -> URL? {
+        let directory = root.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            return directory.appendingPathComponent(fileName, isDirectory: false)
+        } catch {
+            return nil
+        }
+    }
+
+    static func isStoredFile(_ url: URL) -> Bool {
+        url.isFileURL && url.standardizedFileURL.path.hasPrefix(root.standardizedFileURL.path)
+    }
+}
+
+extension HTTPCookie {
+    func klas_matches(_ url: URL) -> Bool {
+        guard let host = url.host?.lowercased() else { return false }
+        let cookieDomain = domain.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        let hostMatches = host == cookieDomain || host.hasSuffix(".\(cookieDomain)")
+        guard hostMatches else { return false }
+        if isSecure && url.scheme?.lowercased() != "https" { return false }
+        let cookiePath = path.isEmpty ? "/" : path
+        let urlPath = url.path.isEmpty ? "/" : url.path
+        return urlPath.hasPrefix(cookiePath)
+    }
+}
+
+class IosFileTransfer: NSObject, URLSessionDownloadDelegate {
+    var onProgress: ((String, Double) -> Void)?
+    var onCompletedFile: ((URL) -> Void)?
+
+    private let policy = FileTransferPolicy.companion.create()
+    private let cookies: DownloadCookieProviding
+    private let injectedSession: URLSession?
+    private var session: URLSession?
+    private var fileName = "download"
+    private var destinationURL: URL?
+    private var continuation: CheckedContinuation<PlatformActionResult, Never>?
+    private var downloadTask: URLSessionDownloadTask?
+
+    init(
+        cookies: DownloadCookieProviding = WKWebsiteCookieProvider(),
+        urlSession: URLSession? = nil
+    ) {
+        self.cookies = cookies
+        self.injectedSession = urlSession
+        super.init()
+    }
+
+    func download(request: FileTransferRequest) async -> PlatformActionResult {
+        let validated = policy.validate(request: request)
+        guard let accepted = validated as? FileTransferValidationAccepted else {
+            return PlatformActionResultFailed(reason: "invalid_download_request")
+        }
+        guard let url = URL(string: accepted.request.url) else {
+            return PlatformActionResultFailed(reason: "invalid_download_request")
+        }
+        fileName = DownloadMetadata.shared.resolvedFileName(request: accepted.request)
+        destinationURL = IosDownloadFileStore.makeDestination(fileName: fileName)
+        guard let destinationURL else {
+            return PlatformActionResultFailed(reason: "download_enqueue_failed")
+        }
+        let cookieHeader = await cookies.cookieHeader(for: url)
+        guard let urlRequest = Self.makeURLRequest(request: accepted.request, cookieHeader: cookieHeader) else {
+            return PlatformActionResultFailed(reason: "invalid_download_request")
+        }
+        // URLSession(delegate:)는 invalidate 전까지 delegate를 강하게 잡으므로 다운로드마다 세션을 만들고 finish에서 정리한다.
+        let activeSession = injectedSession ?? URLSession(
+            configuration: .ephemeral,
+            delegate: self,
+            delegateQueue: .main
+        )
+        session = activeSession
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+            let task = activeSession.downloadTask(with: urlRequest)
+            self.downloadTask = task
+            DispatchQueue.main.async {
+                self.onProgress?(self.fileName, 0)
+            }
+            task.resume()
+        }
+    }
+
+    func cancel() {
+        downloadTask?.cancel()
+        downloadTask = nil
+        finish(PlatformActionResultCancelled())
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard totalBytesExpectedToWrite > 0 else { return }
+        let fraction = Double(totalBytesWritten) / Double(totalBytesExpectedToWrite)
+        onProgress?(fileName, fraction)
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        guard let destinationURL else {
+            finish(PlatformActionResultFailed(reason: "download_enqueue_failed"))
+            return
+        }
+        do {
+            if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+            try FileManager.default.moveItem(at: location, to: destinationURL)
+            onCompletedFile?(destinationURL)
+            finish(PlatformActionResultSuccess())
+        } catch {
+            finish(PlatformActionResultFailed(reason: "download_enqueue_failed"))
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let error else { return }
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            finish(PlatformActionResultCancelled())
+            return
+        }
+        finish(PlatformActionResultFailed(reason: "download_enqueue_failed"))
+    }
+
+    private func finish(_ result: PlatformActionResult) {
+        guard let continuation else { return }
+        self.continuation = nil
+        downloadTask = nil
+        if injectedSession == nil {
+            session?.finishTasksAndInvalidate()
+        }
+        session = nil
+        // 성공 시 완료 파일은 소비자(공유 시트)가 정리한다. 실패/취소는 임시 파일이 남지 않게 여기서 지운다.
+        if !(result is PlatformActionResultSuccess), let destinationURL {
+            try? FileManager.default.removeItem(at: destinationURL.deletingLastPathComponent())
+        }
+        destinationURL = nil
+        continuation.resume(returning: result)
+    }
+
+    static func makeURLRequest(request: FileTransferRequest, cookieHeader: String?) -> URLRequest? {
+        guard let url = URL(string: request.url) else { return nil }
+        var urlRequest = URLRequest(url: url)
+        if let cookieHeader, !cookieHeader.isEmpty {
+            urlRequest.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+        }
+        if let userAgent = request.userAgent, !userAgent.isEmpty {
+            urlRequest.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        }
+        return urlRequest
+    }
+}

--- a/iosApp/iosApp/IosFileTransfer.swift
+++ b/iosApp/iosApp/IosFileTransfer.swift
@@ -17,6 +17,10 @@ struct WKWebsiteCookieProvider: DownloadCookieProviding {
         let cookies: [HTTPCookie] = await withCheckedContinuation { continuation in
             store.getAllCookies { continuation.resume(returning: $0) }
         }
+        return Self.header(from: cookies, for: url)
+    }
+
+    static func header(from cookies: [HTTPCookie], for url: URL) -> String? {
         let matching = cookies.filter { $0.klas_matches(url) }
         let header = HTTPCookie.requestHeaderFields(with: matching)["Cookie"]
         return header?.isEmpty == false ? header : nil

--- a/iosApp/iosApp/IosFileTransfer.swift
+++ b/iosApp/iosApp/IosFileTransfer.swift
@@ -67,6 +67,8 @@ class IosFileTransfer: NSObject, URLSessionDownloadDelegate {
     private let policy = FileTransferPolicy.companion.create()
     private let cookies: DownloadCookieProviding
     private let injectedSession: URLSession?
+    private let stateLock = NSLock()
+    private var downloadInProgress = false
     private var session: URLSession?
     private var fileName = "download"
     private var destinationURL: URL?
@@ -90,6 +92,10 @@ class IosFileTransfer: NSObject, URLSessionDownloadDelegate {
         guard let url = URL(string: accepted.request.url) else {
             return PlatformActionResultFailed(reason: "invalid_download_request")
         }
+        guard beginDownload() else {
+            return PlatformActionResultFailed(reason: "download_already_in_progress")
+        }
+        defer { endDownload() }
         fileName = DownloadMetadata.shared.resolvedFileName(request: accepted.request)
         destinationURL = IosDownloadFileStore.makeDestination(fileName: fileName)
         guard let destinationURL else {
@@ -180,6 +186,20 @@ class IosFileTransfer: NSObject, URLSessionDownloadDelegate {
         }
         destinationURL = nil
         continuation.resume(returning: result)
+    }
+
+    private func beginDownload() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard !downloadInProgress else { return false }
+        downloadInProgress = true
+        return true
+    }
+
+    private func endDownload() {
+        stateLock.lock()
+        downloadInProgress = false
+        stateLock.unlock()
     }
 
     static func makeURLRequest(request: FileTransferRequest, cookieHeader: String?) -> URLRequest? {

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -271,9 +271,26 @@ struct LectureView: View {
                     Image(systemName: "chevron.left")
                 }
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                if model.uiHolder.shareableFileURL != nil || model.klasHolder.shareableFileURL != nil {
+                    Button {
+                        if model.klasHolder.shareableFileURL != nil {
+                            model.klasHolder.shareCurrentFile()
+                        } else {
+                            model.uiHolder.shareCurrentFile()
+                        }
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    .accessibilityIdentifier("pdf_share_button")
+                    .accessibilityLabel("공유")
+                }
+            }
         }
         .webJavaScriptAlert(model.uiHolder)
         .webJavaScriptAlert(model.klasHolder, enabled: model.showingKlas)
+        .webDownloadOverlay(model.uiHolder)
+        .webDownloadOverlay(model.klasHolder)
         .onReceive(model.klasHolder.$navigationState) { state in
             model.handleKlasNavigation(state)
         }

--- a/iosApp/iosApp/LinkWebViewScreen.swift
+++ b/iosApp/iosApp/LinkWebViewScreen.swift
@@ -191,7 +191,7 @@ private struct LinkWebView: UIViewRepresentable {
         private let trustedOrigins = TrustedOriginPolicy(
             trustedOrigins: TrustedOriginPolicy.companion.DEFAULT_TRUSTED_ORIGINS
         )
-        private let externalPolicy = ExternalNavigationPolicy(maximumLength: 2048)
+        private let navigator = IosExternalNavigator.companion.system()
 
         init(onClose: @escaping () -> Void) {
             self.onClose = onClose
@@ -224,10 +224,7 @@ private struct LinkWebView: UIViewRepresentable {
                 return
             }
 
-            let resolution = externalPolicy.resolve(rawValue: urlString)
-            if let allowed = resolution as? ExternalNavigationResolutionAllowed {
-                openExternal(allowed.destination)
-            }
+            _ = navigator.openValidated(rawValue: urlString)
             decisionHandler(.cancel)
         }
 
@@ -274,32 +271,10 @@ private struct LinkWebView: UIViewRepresentable {
                 if trustedOrigins.isTrustedUrl(url: urlString) {
                     webView.load(navigationAction.request)
                 } else {
-                    let resolution = externalPolicy.resolve(rawValue: urlString)
-                    if let allowed = resolution as? ExternalNavigationResolutionAllowed {
-                        openExternal(allowed.destination)
-                    }
+                    _ = navigator.openValidated(rawValue: urlString)
                 }
             }
             return nil
-        }
-
-        private func openExternal(_ destination: ExternalDestination) {
-            let raw: String
-            if let web = destination as? ExternalDestinationWeb {
-                raw = web.url
-            } else if let email = destination as? ExternalDestinationEmail {
-                raw = "mailto:\(email.address)"
-            } else if let tel = destination as? ExternalDestinationTelephone {
-                raw = "tel:\(tel.number)"
-            } else if let platform = destination as? ExternalDestinationPlatformUri {
-                raw = platform.uri
-            } else {
-                return
-            }
-            guard let url = URL(string: raw) else { return }
-            DispatchQueue.main.async {
-                UIApplication.shared.open(url)
-            }
         }
     }
 }

--- a/iosApp/iosApp/PushedWebStack.swift
+++ b/iosApp/iosApp/PushedWebStack.swift
@@ -20,8 +20,18 @@ struct PushedWebStack: View {
                     Image(systemName: "chevron.left")
                 }
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                if holder.shareableFileURL != nil {
+                    Button(action: { holder.shareCurrentFile() }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    .accessibilityIdentifier("pdf_share_button")
+                    .accessibilityLabel("공유")
+                }
+            }
         }
         .webJavaScriptAlert(holder)
+        .webDownloadOverlay(holder)
     }
 }
 

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -11,6 +11,9 @@ final class WebViewHolder: NSObject, ObservableObject {
     @Published private(set) var navigationState = WebNavigationState()
     @Published private(set) var lastExternalURL: String?
     @Published var javaScriptAlertMessage: String?
+    @Published private(set) var downloadProgress: DownloadProgressState?
+    @Published private(set) var downloadErrorMessage: String?
+    @Published private(set) var shareableFileURL: URL?
 
     private var _webView: WKWebView?
     private var bridgeAdapter: IosBridgeMessageAdapter?
@@ -18,7 +21,11 @@ final class WebViewHolder: NSObject, ObservableObject {
     private lazy var navigationRelay = NavigationRelay(owner: self)
     private lazy var uiRelay = UIRelay(owner: self)
     private let trustedOrigins = TrustedOriginPolicy(trustedOrigins: TrustedOriginPolicy.companion.DEFAULT_TRUSTED_ORIGINS)
-    private let externalPolicy = ExternalNavigationPolicy(maximumLength: 2048)
+    private let fileTransferPolicy = FileTransferPolicy.companion.create()
+    private let navigator: IosExternalNavigator
+    private let filePicker: IosFilePicker
+    private let fileTransfer: IosFileTransfer
+    private var loadingLocalPdf = false
 
     static var websiteDataStore: WKWebsiteDataStore { .default() }
 
@@ -27,6 +34,23 @@ final class WebViewHolder: NSObject, ObservableObject {
         let build = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String ?? "1"
         let digits = build.split(whereSeparator: { !$0.isNumber }).first.flatMap { Int($0) } ?? 1
         return "iOSApp_v\(max(digits, 1))"
+    }
+
+    init(
+        navigator: IosExternalNavigator = IosExternalNavigator.companion.system(),
+        filePicker: IosFilePicker = IosFilePicker(),
+        fileTransfer: IosFileTransfer = IosFileTransfer()
+    ) {
+        self.navigator = navigator
+        self.filePicker = filePicker
+        self.fileTransfer = fileTransfer
+        super.init()
+        fileTransfer.onProgress = { [weak self] fileName, fraction in
+            self?.downloadProgress = DownloadProgressState(fileName: fileName, fraction: fraction)
+        }
+        fileTransfer.onCompletedFile = { [weak self] url in
+            self?.handleCompletedFile(url)
+        }
     }
 
     var webView: WKWebView {
@@ -151,11 +175,27 @@ final class WebViewHolder: NSObject, ObservableObject {
         return true
     }
 
+    func shareCurrentFile() {
+        guard let shareableFileURL else { return }
+        presentShareSheet(url: shareableFileURL, deleteWhenDone: false)
+    }
+
+    func cancelDownload() {
+        fileTransfer.cancel()
+        clearDownload()
+    }
+
+    func clearDownloadError() {
+        downloadErrorMessage = nil
+    }
+
     func dispose() {
         guard !isDisposed else { return }
         isDisposed = true
         bridgeAdapter?.dispose()
         bridgeAdapter = nil
+        cancelDownload()
+        clearInlinePdf()
         guard let view = _webView else {
             navigationState = WebNavigationState(loadPhase: .disposed)
             return
@@ -171,18 +211,18 @@ final class WebViewHolder: NSObject, ObservableObject {
         navigationState = WebNavigationState(loadPhase: .disposed)
     }
 
-    fileprivate func handleDecidePolicy(urlString: String, isMainFrame: Bool) -> Bool {
+    func handleDecidePolicy(urlString: String, isMainFrame: Bool) -> Bool {
         guard !isDisposed else { return false }
         guard isMainFrame else { return true }
+        if let url = URL(string: urlString), IosDownloadFileStore.isStoredFile(url) {
+            return true
+        }
 
         if trustedOrigins.isTrustedUrl(url: urlString) {
             return true
         }
 
-        let resolution = externalPolicy.resolve(rawValue: urlString)
-        if let allowed = resolution as? ExternalNavigationResolutionAllowed {
-            openExternal(allowed.destination)
-        }
+        openExternal(urlString)
         return false
     }
 
@@ -192,15 +232,17 @@ final class WebViewHolder: NSObject, ObservableObject {
         if trustedOrigins.isTrustedUrl(url: urlString) {
             load(urlString)
         } else {
-            let resolution = externalPolicy.resolve(rawValue: urlString)
-            if let allowed = resolution as? ExternalNavigationResolutionAllowed {
-                openExternal(allowed.destination)
-            }
+            openExternal(urlString)
         }
     }
 
     fileprivate func navigationDidStart(url: String?) {
         guard !isDisposed, let view = _webView else { return }
+        if loadingLocalPdf {
+            loadingLocalPdf = false
+        } else {
+            clearInlinePdf()
+        }
         let phase: WebLoadPhase = url.map { .loading(url: $0) } ?? .loading(url: view.url?.absoluteString ?? "")
         navigationState = WebNavigationState(
             loadPhase: phase,
@@ -219,26 +261,114 @@ final class WebViewHolder: NSObject, ObservableObject {
         )
     }
 
-    func handleNavigationResponse(_ response: URLResponse, isMainFrame: Bool) -> Bool {
-        guard !isDisposed else { return false }
-        guard isMainFrame,
-              let httpResponse = response as? HTTPURLResponse,
-              (400...599).contains(httpResponse.statusCode) else {
+    func handleNavigationResponse(
+        _ response: URLResponse,
+        isMainFrame: Bool,
+        canShowMIMEType: Bool
+    ) -> WKNavigationResponsePolicy {
+        guard !isDisposed else { return .cancel }
+        if isMainFrame,
+           let httpResponse = response as? HTTPURLResponse,
+           (400...599).contains(httpResponse.statusCode) {
+            guard let view = _webView else { return .cancel }
+            navigationState = WebNavigationState(
+                loadPhase: .failed(url: response.url?.absoluteString, category: .http),
+                canGoBack: view.canGoBack,
+                canGoForward: view.canGoForward
+            )
+            return .cancel
+        }
+
+        if let url = response.url, IosDownloadFileStore.isStoredFile(url) {
+            return .allow
+        }
+
+        // PDF는 공유 시트로 보내지 않는다. attachment/octet-stream은 받아서 웹뷰에 연다.
+        if looksLikePdf(response) {
+            let request = makeDownloadRequest(response)
+            let accepted = fileTransferPolicy.validate(request: request) is FileTransferValidationAccepted
+            if canShowInWebView(response, canShowMIMEType: canShowMIMEType), accepted {
+                return .allow
+            }
+            if accepted {
+                startDownload(request)
+            }
+            return .cancel
+        }
+
+        if isDownloadCandidate(response, canShowMIMEType: canShowMIMEType) {
+            if isAcceptedDownload(response) {
+                startDownload(makeDownloadRequest(response))
+            }
+            return .cancel
+        }
+        clearInlinePdf()
+        return .allow
+    }
+
+    private func looksLikePdf(_ response: URLResponse) -> Bool {
+        if DownloadMetadata.shared.looksLikePdf(
+            mimeType: response.mimeType,
+            contentDisposition: (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Disposition"),
+            url: response.url?.absoluteString
+        ) {
             return true
         }
-        guard let view = _webView else { return false }
-        navigationState = WebNavigationState(
-            loadPhase: .failed(url: response.url?.absoluteString, category: .http),
-            canGoBack: view.canGoBack,
-            canGoForward: view.canGoForward
+        return (response.suggestedFilename ?? "").lowercased().hasSuffix(".pdf")
+    }
+
+    private func canShowInWebView(_ response: URLResponse, canShowMIMEType: Bool) -> Bool {
+        guard canShowMIMEType else { return false }
+        let disposition = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Disposition")?.lowercased() ?? ""
+        if disposition.contains("attachment") { return false }
+        let mime = response.mimeType?
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
+            .first
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+        if mime == "application/octet-stream" { return false }
+        return true
+    }
+
+    private func clearInlinePdf() {
+        if let local = shareableFileURL {
+            Self.removeDownloadDirectory(for: local)
+        }
+        shareableFileURL = nil
+    }
+
+    func isDownloadCandidate(_ response: URLResponse, canShowMIMEType: Bool) -> Bool {
+        let disposition = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Disposition")
+        return fileTransferPolicy.shouldTreatAsDownload(
+            mimeType: response.mimeType,
+            contentDisposition: disposition,
+            canShowMimeType: canShowMIMEType,
+            url: response.url?.absoluteString
         )
-        return false
+    }
+
+    func isAcceptedDownload(_ response: URLResponse) -> Bool {
+        fileTransferPolicy.validate(request: makeDownloadRequest(response)) is FileTransferValidationAccepted
+    }
+
+    private func makeDownloadRequest(_ response: URLResponse) -> FileTransferRequest {
+        FileTransferRequest(
+            url: response.url?.absoluteString ?? "",
+            suggestedFileName: response.suggestedFilename,
+            mimeType: response.mimeType,
+            userAgent: _webView?.value(forKey: "userAgent") as? String,
+            contentDisposition: (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "Content-Disposition")
+        )
     }
 
     fileprivate func navigationDidFail(url: String?, error: Error) {
         guard !isDisposed, let view = _webView else { return }
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            return
+        }
+        // 다운로드, 외부 이동으로 내비게이션을 끊으면 WebKit이 102를 남긴다.
+        if nsError.code == 102,
+           nsError.domain == "WebKitErrorDomain" || nsError.domain == WKError.errorDomain {
             return
         }
         let category: WebNavFailureCategory
@@ -262,6 +392,96 @@ final class WebViewHolder: NSObject, ObservableObject {
         )
     }
 
+    private func startDownload(_ request: FileTransferRequest) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let result = await self.fileTransfer.download(request: request)
+            self.handleDownloadResult(result)
+        }
+    }
+
+    private func handleCompletedFile(_ url: URL) {
+        if url.pathExtension.lowercased() == "pdf" {
+            openLocalPdf(url)
+            return
+        }
+        presentShareSheet(url: url, deleteWhenDone: true)
+    }
+
+    private func openLocalPdf(_ url: URL) {
+        if let previous = shareableFileURL, previous != url {
+            Self.removeDownloadDirectory(for: previous)
+        }
+        shareableFileURL = url
+        loadingLocalPdf = true
+        webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+    }
+
+    private func handleDownloadResult(_ result: PlatformActionResult) {
+        clearDownload()
+        if result is PlatformActionResultFailed {
+            downloadErrorMessage = "다운로드에 실패했습니다."
+        }
+    }
+
+    fileprivate func handleOpenPanel(allowMultiple: Bool, completionHandler: @escaping ([URL]?) -> Void) {
+        filePicker.pickForWeb(
+            allowMultiple: allowMultiple,
+            from: _webView?.klas_presentingViewController,
+            completion: completionHandler
+        )
+    }
+
+    private func openExternal(_ raw: String) {
+        let result = navigator.openValidated(rawValue: raw)
+        if result is PlatformActionResultSuccess {
+            lastExternalURL = raw
+        }
+    }
+
+    private func presentShareSheet(url: URL, deleteWhenDone: Bool) {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            if deleteWhenDone {
+                Self.removeDownloadDirectory(for: url)
+            }
+            downloadErrorMessage = "다운로드에 실패했습니다."
+            return
+        }
+        // 진행 overlay가 내려간 다음 런루프에서 올려야 iPhone에서 sheet가 가려지지 않는다.
+        DispatchQueue.main.async { [weak self] in
+            self?.presentActivityController(for: url, deleteWhenDone: deleteWhenDone)
+        }
+    }
+
+    private func presentActivityController(for url: URL, deleteWhenDone: Bool) {
+        let activity = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        if deleteWhenDone {
+            activity.completionWithItemsHandler = { _, _, _, _ in
+                Self.removeDownloadDirectory(for: url)
+            }
+        }
+        if let popover = activity.popoverPresentationController, let webView = _webView {
+            popover.sourceView = webView
+            popover.sourceRect = CGRect(x: webView.bounds.midX, y: webView.bounds.midY, width: 1, height: 1)
+        }
+        var presenter = _webView?.klas_presentingViewController ?? UIView.klas_keyWindowRootViewController
+        while let presented = presenter?.presentedViewController {
+            presenter = presented
+        }
+        guard let presenter else {
+            if deleteWhenDone {
+                Self.removeDownloadDirectory(for: url)
+            }
+            downloadErrorMessage = "다운로드에 실패했습니다."
+            return
+        }
+        presenter.present(activity, animated: true)
+    }
+
+    private static func removeDownloadDirectory(for fileURL: URL) {
+        try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent())
+    }
+
     private func publishNavigationFlags(from view: WKWebView) {
         var next = navigationState
         next.canGoBack = view.canGoBack
@@ -269,24 +489,8 @@ final class WebViewHolder: NSObject, ObservableObject {
         navigationState = next
     }
 
-    private func openExternal(_ destination: ExternalDestination) {
-        let raw: String
-        if let web = destination as? ExternalDestinationWeb {
-            raw = web.url
-        } else if let email = destination as? ExternalDestinationEmail {
-            raw = "mailto:\(email.address)"
-        } else if let tel = destination as? ExternalDestinationTelephone {
-            raw = "tel:\(tel.number)"
-        } else if let platform = destination as? ExternalDestinationPlatformUri {
-            raw = platform.uri
-        } else {
-            return
-        }
-        lastExternalURL = raw
-        guard let url = URL(string: raw) else { return }
-        DispatchQueue.main.async {
-            UIApplication.shared.open(url)
-        }
+    private func clearDownload() {
+        downloadProgress = nil
     }
 }
 
@@ -317,11 +521,12 @@ private final class NavigationRelay: NSObject, WKNavigationDelegate {
         decidePolicyFor navigationResponse: WKNavigationResponse,
         decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
     ) {
-        let allow = owner?.handleNavigationResponse(
+        let policy = owner?.handleNavigationResponse(
             navigationResponse.response,
-            isMainFrame: navigationResponse.isForMainFrame
-        ) ?? false
-        decisionHandler(allow ? .allow : .cancel)
+            isMainFrame: navigationResponse.isForMainFrame,
+            canShowMIMEType: navigationResponse.canShowMIMEType
+        ) ?? .cancel
+        decisionHandler(policy)
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -349,7 +554,7 @@ private final class UIRelay: NSObject, WKUIDelegate {
     weak var owner: WebViewHolder?
 
     init(owner: WebViewHolder) {
-        self.owner = owner;
+        self.owner = owner
     }
 
     func webView(
@@ -369,5 +574,15 @@ private final class UIRelay: NSObject, WKUIDelegate {
         completionHandler: @escaping () -> Void
     ) {
         owner?.presentJavaScriptAlert(message: message, completion: completionHandler)
+    }
+
+    @available(iOS 18.4, *)
+    func webView(
+        _ webView: WKWebView,
+        runOpenPanelWith parameters: WKOpenPanelParameters,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping ([URL]?) -> Void
+    ) {
+        owner?.handleOpenPanel(allowMultiple: parameters.allowsMultipleSelection, completionHandler: completionHandler)
     }
 }

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -25,6 +25,7 @@ final class WebViewHolder: NSObject, ObservableObject {
     private let navigator: IosExternalNavigator
     private let filePicker: IosFilePicker
     private let fileTransfer: IosFileTransfer
+    private var activeDownloadTask: Task<Void, Never>?
     private var loadingLocalPdf = false
 
     static var websiteDataStore: WKWebsiteDataStore { .default() }
@@ -393,8 +394,10 @@ final class WebViewHolder: NSObject, ObservableObject {
     }
 
     private func startDownload(_ request: FileTransferRequest) {
-        Task { @MainActor [weak self] in
+        guard activeDownloadTask == nil else { return }
+        activeDownloadTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            defer { self.activeDownloadTask = nil }
             let result = await self.fileTransfer.download(request: request)
             self.handleDownloadResult(result)
         }

--- a/iosApp/iosAppTests/IosBridgeMessageAdapterTests.swift
+++ b/iosApp/iosAppTests/IosBridgeMessageAdapterTests.swift
@@ -254,7 +254,10 @@ final class IosBridgeMessageAdapterTests: XCTestCase {
             HTTPURLResponse(url: url, statusCode: 404, httpVersion: nil, headerFields: nil)
         )
 
-        XCTAssertFalse(holder.handleNavigationResponse(response, isMainFrame: true))
+        XCTAssertEqual(
+            holder.handleNavigationResponse(response, isMainFrame: true, canShowMIMEType: true),
+            .cancel
+        )
         guard case .failed(let failedURL, let category) = holder.navigationState.loadPhase else {
             return XCTFail("HTTP 오류가 실패 상태로 기록되지 않음")
         }

--- a/iosApp/iosAppTests/IosFilePortsTests.swift
+++ b/iosApp/iosAppTests/IosFilePortsTests.swift
@@ -1,0 +1,464 @@
+import Foundation
+import Shared
+import UIKit
+import WebKit
+import XCTest
+@testable import kw_klas_plus
+
+final class IosFilePortsTests: XCTestCase {
+    func testExternalNavigationAllowsMailtoTelHttpsAndRejectsMaliciousSchemes() {
+        let opener = RecordingUrlOpener()
+        let holder = WebViewHolder(navigator: IosExternalNavigator(opener: opener))
+        defer { holder.dispose() }
+
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "mailto:help@example.com", isMainFrame: true))
+        XCTAssertEqual(holder.lastExternalURL, "mailto:help@example.com")
+        XCTAssertEqual(opener.opened, ["mailto:help@example.com"])
+
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "tel:+82-2-123-4567", isMainFrame: true))
+        XCTAssertEqual(holder.lastExternalURL, "tel:+82-2-123-4567")
+
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "https://example.com/help", isMainFrame: true))
+        XCTAssertEqual(holder.lastExternalURL, "https://example.com/help")
+
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "javascript:alert(1)", isMainFrame: true))
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "intent://settings", isMainFrame: true))
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "file:///tmp/secret", isMainFrame: true))
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "https://user@example.com", isMainFrame: true))
+        XCTAssertEqual(holder.lastExternalURL, "https://example.com/help")
+        XCTAssertEqual(
+            opener.opened,
+            [
+                "mailto:help@example.com",
+                "tel:+82-2-123-4567",
+                "https://example.com/help",
+            ]
+        )
+
+        XCTAssertTrue(holder.handleDecidePolicy(urlString: "https://klasplus.yuntae.in/feed", isMainFrame: true))
+    }
+
+    func testDownloadDispatchAndInlinePdfHandling() throws {
+        let transfer = RecordingFileTransfer()
+        let dispatched = expectation(description: "downloads dispatched to FileTransfer")
+        dispatched.expectedFulfillmentCount = 2
+        transfer.onDownload = { dispatched.fulfill() }
+        let holder = WebViewHolder(
+            navigator: IosExternalNavigator(opener: RecordingUrlOpener()),
+            fileTransfer: transfer
+        )
+        defer { holder.dispose() }
+        let url = URL(string: "https://klas.kw.ac.kr/std/file")!
+
+        let attachmentPdf = try XCTUnwrap(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "application/octet-stream",
+                    "Content-Disposition": "attachment; filename=\"컴퓨터구조_15주차_강의자료.pdf\"",
+                ]
+            )
+        )
+        XCTAssertEqual(
+            holder.handleNavigationResponse(attachmentPdf, isMainFrame: true, canShowMIMEType: false),
+            .cancel
+        )
+
+        let binary = try XCTUnwrap(
+            HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
+        )
+        XCTAssertEqual(
+            holder.handleNavigationResponse(binary, isMainFrame: true, canShowMIMEType: false),
+            .cancel
+        )
+        XCTAssertEqual(
+            holder.handleNavigationResponse(binary, isMainFrame: true, canShowMIMEType: true),
+            .allow
+        )
+
+        let inlinePdf = try XCTUnwrap(
+            HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "application/pdf",
+                    "Content-Disposition": "inline; filename=\"week15.pdf\"",
+                ]
+            )
+        )
+        XCTAssertEqual(
+            holder.handleNavigationResponse(inlinePdf, isMainFrame: true, canShowMIMEType: true),
+            .allow
+        )
+
+        wait(for: [dispatched], timeout: 2)
+        XCTAssertEqual(transfer.requests.map { $0.url }, Array(repeating: url.absoluteString, count: 2))
+    }
+
+    func testLocalDownloadedPdfIsAllowedInWebView() throws {
+        let holder = WebViewHolder(
+            navigator: IosExternalNavigator(opener: RecordingUrlOpener()),
+            fileTransfer: RecordingFileTransfer()
+        )
+        defer { holder.dispose() }
+        let fileURL = try XCTUnwrap(IosDownloadFileStore.makeDestination(fileName: "week15.pdf"))
+        defer { try? FileManager.default.removeItem(at: fileURL.deletingLastPathComponent()) }
+        try Data("%PDF-1.4".utf8).write(to: fileURL)
+        let response = try XCTUnwrap(
+            HTTPURLResponse(url: fileURL, statusCode: 200, httpVersion: nil, headerFields: [
+                "Content-Type": "application/pdf",
+            ])
+        )
+        XCTAssertEqual(
+            holder.handleNavigationResponse(response, isMainFrame: true, canShowMIMEType: true),
+            .allow
+        )
+    }
+
+    func testRejectedDownloadUrlDoesNotBecomeDownload() throws {
+        let transfer = RecordingFileTransfer()
+        let holder = WebViewHolder(
+            navigator: IosExternalNavigator(opener: RecordingUrlOpener()),
+            fileTransfer: transfer
+        )
+        defer { holder.dispose() }
+        let fileURL = URL(string: "file:///tmp/secret.pdf")!
+        let response = try XCTUnwrap(
+            HTTPURLResponse(
+                url: fileURL,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Disposition": "attachment; filename=\"secret.pdf\""]
+            )
+        )
+        XCTAssertFalse(holder.isDownloadCandidate(response, canShowMIMEType: true))
+        XCTAssertFalse(holder.isAcceptedDownload(response))
+        XCTAssertEqual(
+            holder.handleNavigationResponse(response, isMainFrame: true, canShowMIMEType: true),
+            .cancel
+        )
+        XCTAssertTrue(transfer.requests.isEmpty)
+    }
+
+    func testDownloadRequestIncludesCookieHeaderAndRejectsNonWebUrl() async {
+        let request = FileTransferRequest(
+            url: "https://klas.kw.ac.kr/std/file",
+            suggestedFileName: "a.pdf",
+            mimeType: "application/pdf",
+            userAgent: "iOSApp_v1",
+            contentDisposition: nil
+        )
+        let urlRequest = IosFileTransfer.makeURLRequest(request: request, cookieHeader: "SESSION=token")
+        XCTAssertEqual(urlRequest?.value(forHTTPHeaderField: "Cookie"), "SESSION=token")
+        XCTAssertEqual(urlRequest?.value(forHTTPHeaderField: "User-Agent"), "iOSApp_v1")
+
+        let transfer = IosFileTransfer(cookies: StaticCookieProvider(header: "SESSION=token"))
+        let rejected = await transfer.download(
+            request: FileTransferRequest(
+                url: "javascript:download()",
+                suggestedFileName: nil,
+                mimeType: nil,
+                userAgent: nil,
+                contentDisposition: nil
+            )
+        )
+        XCTAssertTrue(rejected is PlatformActionResultFailed)
+    }
+
+    func testKlasMatchesCookieDomainPathAndSecure() {
+        let downloadURL = URL(string: "https://klas.kw.ac.kr/std/file")!
+        let httpURL = URL(string: "http://klas.kw.ac.kr/std/file")!
+        let otherHost = URL(string: "https://example.com/std/file")!
+        let adminURL = URL(string: "https://klas.kw.ac.kr/admin/file")!
+
+        let session = makeTestCookie(name: "SESSION", value: "klas-session", domain: ".kw.ac.kr", path: "/", secure: true)
+        let otherSite = makeTestCookie(name: "OTHER", value: "nope", domain: "example.com", path: "/")
+        let adminOnly = makeTestCookie(name: "ADMIN", value: "nope", domain: "klas.kw.ac.kr", path: "/admin")
+
+        let cases: [(HTTPCookie, URL, Bool)] = [
+            (session, downloadURL, true),
+            (session, httpURL, false),
+            (session, otherHost, false),
+            (otherSite, downloadURL, false),
+            (adminOnly, downloadURL, false),
+            (adminOnly, adminURL, true),
+        ]
+        for (cookie, url, expected) in cases {
+            let matched = cookie.klas_matches(url)
+            print(
+                "[download-cookie] match=\(matched) expected=\(expected) " +
+                "\(cookie.name)=\(cookie.value) domain=\(cookie.domain) path=\(cookie.path) " +
+                "secure=\(cookie.isSecure) url=\(url.absoluteString)"
+            )
+            XCTAssertEqual(matched, expected, "\(cookie.name) vs \(url.absoluteString)")
+        }
+    }
+
+    @MainActor
+    func testCookieHeaderIncludesOnlyMatchingStoreCookies() async {
+        let url = URL(string: "https://klas.kw.ac.kr/std/file")!
+        let cookies = [
+            makeTestCookie(name: "SESSION", value: "klas-session", domain: ".kw.ac.kr", path: "/", secure: true),
+            makeTestCookie(name: "OTHER", value: "nope", domain: "example.com", path: "/"),
+            makeTestCookie(name: "ADMIN", value: "nope", domain: "klas.kw.ac.kr", path: "/admin"),
+        ]
+        let header = WKWebsiteCookieProvider.header(from: cookies, for: url)
+        logDownloadCookies(cookies, url: url, header: header)
+        XCTAssertEqual(header, "SESSION=klas-session")
+
+        let dataStore = WKWebsiteDataStore.nonPersistent()
+        let store = dataStore.httpCookieStore
+        for cookie in cookies {
+            await setCookie(cookie, on: store)
+        }
+        let storedHeader = await WKWebsiteCookieProvider(store: store).cookieHeader(for: url)
+        print("[download-cookie] store header=\(storedHeader ?? "<nil>")")
+        XCTAssertEqual(storedHeader, "SESSION=klas-session")
+
+        let request = FileTransferRequest(
+            url: url.absoluteString,
+            suggestedFileName: "a.pdf",
+            mimeType: "application/pdf",
+            userAgent: "iOSApp_v1",
+            contentDisposition: nil
+        )
+        let urlRequest = IosFileTransfer.makeURLRequest(request: request, cookieHeader: storedHeader)
+        print("[download-cookie] URLRequest Cookie=\(urlRequest?.value(forHTTPHeaderField: "Cookie") ?? "<nil>")")
+        XCTAssertEqual(urlRequest?.value(forHTTPHeaderField: "Cookie"), "SESSION=klas-session")
+    }
+
+    func testDownloadSendsMatchedCookieHeader() async {
+        let url = URL(string: "https://klas.kw.ac.kr/std/file")!
+        let cookies = [
+            makeTestCookie(name: "SESSION", value: "klas-session", domain: ".kw.ac.kr", path: "/", secure: true),
+            makeTestCookie(name: "OTHER", value: "nope", domain: "example.com", path: "/"),
+        ]
+        RecordingCookieURLProtocol.reset()
+        let started = expectation(description: "download request started")
+        RecordingCookieURLProtocol.started = started
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [RecordingCookieURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let transfer = IosFileTransfer(
+            cookies: FilteringCookieProvider(cookies: cookies),
+            urlSession: session
+        )
+        let download = Task {
+            await transfer.download(
+                request: FileTransferRequest(
+                    url: url.absoluteString,
+                    suggestedFileName: "a.pdf",
+                    mimeType: "application/pdf",
+                    userAgent: "iOSApp_v1",
+                    contentDisposition: nil
+                )
+            )
+        }
+        await fulfillment(of: [started], timeout: 3)
+        let sent = RecordingCookieURLProtocol.cookieHeader
+        print("[download-cookie] sent Cookie=\(sent ?? "<nil>")")
+        logDownloadCookies(cookies, url: url, header: sent)
+        XCTAssertEqual(sent, "SESSION=klas-session")
+        transfer.cancel()
+        _ = await download.value
+        RecordingCookieURLProtocol.reset()
+    }
+
+    func testFileTransferCancelReturnsCancelled() async {
+        let started = expectation(description: "request started")
+        HangingURLProtocol.started = started
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [HangingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let transfer = IosFileTransfer(
+            cookies: StaticCookieProvider(header: "SESSION=token"),
+            urlSession: session
+        )
+        let download = Task {
+            await transfer.download(
+                request: FileTransferRequest(
+                    url: "https://klas.kw.ac.kr/std/file",
+                    suggestedFileName: "a.pdf",
+                    mimeType: "application/pdf",
+                    userAgent: nil,
+                    contentDisposition: nil
+                )
+            )
+        }
+        await fulfillment(of: [started], timeout: 3)
+        transfer.cancel()
+        let result = await download.value
+        XCTAssertTrue(result is PlatformActionResultCancelled)
+        HangingURLProtocol.started = nil
+    }
+
+    func testFilePickerCancelSingleAndMultiple() {
+        let presenter = RecordingFilePickerPresenter()
+        let picker = IosFilePicker(presenter: presenter)
+
+        presenter.result = FilePickerResultCancelled()
+        let cancelled = expectation(description: "cancelled")
+        picker.pickForWeb(allowMultiple: false, from: nil) { urls in
+            XCTAssertNil(urls)
+            cancelled.fulfill()
+        }
+        wait(for: [cancelled], timeout: 1)
+        XCTAssertEqual(presenter.allowMultiple, false)
+
+        presenter.result = FilePickerResultSelected(references: ["file:///tmp/a", "file:///tmp/b"])
+        let selected = expectation(description: "selected")
+        picker.pickForWeb(allowMultiple: true, from: nil) { urls in
+            XCTAssertEqual(urls?.map(\.absoluteString), ["file:///tmp/a", "file:///tmp/b"])
+            selected.fulfill()
+        }
+        wait(for: [selected], timeout: 1)
+        XCTAssertEqual(presenter.allowMultiple, true)
+    }
+
+    func testCancelDownloadWithoutActiveDownloadIsSafe() {
+        let holder = WebViewHolder(navigator: IosExternalNavigator(opener: RecordingUrlOpener()))
+        holder.cancelDownload()
+        XCTAssertNil(holder.downloadProgress)
+        XCTAssertNil(holder.shareableFileURL)
+        holder.shareCurrentFile()
+        holder.dispose()
+    }
+}
+
+final class RecordingUrlOpener: IosUrlOpener {
+    private(set) var opened: [String] = []
+
+    func open(url: URL) -> Bool {
+        opened.append(url.absoluteString)
+        return true
+    }
+}
+
+final class RecordingFilePickerPresenter: FilePickerPresenting {
+    var allowMultiple: Bool?
+    var result: FilePickerResult = FilePickerResultCancelled()
+
+    func present(
+        allowMultiple: Bool,
+        from presenter: UIViewController?,
+        completion: @escaping (FilePickerResult) -> Void
+    ) {
+        self.allowMultiple = allowMultiple
+        completion(result)
+    }
+}
+
+struct StaticCookieProvider: DownloadCookieProviding {
+    let header: String?
+    func cookieHeader(for url: URL) async -> String? { header }
+}
+
+struct FilteringCookieProvider: DownloadCookieProviding {
+    let cookies: [HTTPCookie]
+    func cookieHeader(for url: URL) async -> String? {
+        WKWebsiteCookieProvider.header(from: cookies, for: url)
+    }
+}
+
+private func makeTestCookie(
+    name: String,
+    value: String,
+    domain: String,
+    path: String = "/",
+    secure: Bool = false
+) -> HTTPCookie {
+    var properties: [HTTPCookiePropertyKey: Any] = [
+        .name: name,
+        .value: value,
+        .domain: domain,
+        .path: path,
+    ]
+    if secure {
+        properties[.secure] = "TRUE"
+    }
+    return HTTPCookie(properties: properties)!
+}
+
+@MainActor
+private func setCookie(_ cookie: HTTPCookie, on store: WKHTTPCookieStore) async {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+        store.setCookie(cookie) {
+            continuation.resume()
+        }
+    }
+}
+
+private func logDownloadCookies(_ cookies: [HTTPCookie], url: URL, header: String?) {
+    print("[download-cookie] url=\(url.absoluteString)")
+    for cookie in cookies {
+        print(
+            "[download-cookie] \(cookie.name)=\(cookie.value) " +
+            "domain=\(cookie.domain) path=\(cookie.path) secure=\(cookie.isSecure) " +
+            "match=\(cookie.klas_matches(url))"
+        )
+    }
+    print("[download-cookie] Cookie header=\(header ?? "<nil>")")
+}
+
+final class RecordingFileTransfer: IosFileTransfer {
+    var onDownload: (() -> Void)?
+    var result: PlatformActionResult = PlatformActionResultSuccess()
+
+    private let lock = NSLock()
+    private var storedRequests: [FileTransferRequest] = []
+    var requests: [FileTransferRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedRequests
+    }
+
+    override func download(request: FileTransferRequest) async -> PlatformActionResult {
+        lock.lock()
+        storedRequests.append(request)
+        lock.unlock()
+        onDownload?()
+        return result
+    }
+
+    override func cancel() {}
+}
+
+final class HangingURLProtocol: URLProtocol {
+    static var started: XCTestExpectation?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        DispatchQueue.main.async {
+            HangingURLProtocol.started?.fulfill()
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+final class RecordingCookieURLProtocol: URLProtocol {
+    static var started: XCTestExpectation?
+    static var cookieHeader: String?
+
+    static func reset() {
+        started = nil
+        cookieHeader = nil
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        Self.cookieHeader = request.value(forHTTPHeaderField: "Cookie")
+        DispatchQueue.main.async {
+            Self.started?.fulfill()
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/iosApp/iosAppTests/IosFilePortsTests.swift
+++ b/iosApp/iosAppTests/IosFilePortsTests.swift
@@ -38,10 +38,9 @@ final class IosFilePortsTests: XCTestCase {
         XCTAssertTrue(holder.handleDecidePolicy(urlString: "https://klasplus.yuntae.in/feed", isMainFrame: true))
     }
 
-    func testDownloadDispatchAndInlinePdfHandling() throws {
+    func testDownloadDispatchIsSingleFlightAndInlinePdfHandling() throws {
         let transfer = RecordingFileTransfer()
         let dispatched = expectation(description: "downloads dispatched to FileTransfer")
-        dispatched.expectedFulfillmentCount = 2
         transfer.onDownload = { dispatched.fulfill() }
         let holder = WebViewHolder(
             navigator: IosExternalNavigator(opener: RecordingUrlOpener()),
@@ -95,7 +94,7 @@ final class IosFilePortsTests: XCTestCase {
         )
 
         wait(for: [dispatched], timeout: 2)
-        XCTAssertEqual(transfer.requests.map { $0.url }, Array(repeating: url.absoluteString, count: 2))
+        XCTAssertEqual(transfer.requests.map { $0.url }, [url.absoluteString])
     }
 
     func testLocalDownloadedPdfIsAllowedInWebView() throws {
@@ -292,6 +291,37 @@ final class IosFilePortsTests: XCTestCase {
         transfer.cancel()
         let result = await download.value
         XCTAssertTrue(result is PlatformActionResultCancelled)
+        HangingURLProtocol.started = nil
+    }
+
+    func testFileTransferRejectsOverlappingDownloadUntilFirstCompletes() async {
+        let started = expectation(description: "first request started")
+        HangingURLProtocol.started = started
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [HangingURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let transfer = IosFileTransfer(
+            cookies: StaticCookieProvider(header: "SESSION=token"),
+            urlSession: session
+        )
+        let request = FileTransferRequest(
+            url: "https://klas.kw.ac.kr/std/file",
+            suggestedFileName: "a.pdf",
+            mimeType: "application/pdf",
+            userAgent: nil,
+            contentDisposition: nil
+        )
+        let firstDownload = Task {
+            await transfer.download(request: request)
+        }
+
+        await fulfillment(of: [started], timeout: 3)
+        let overlappingResult = await transfer.download(request: request)
+        XCTAssertTrue(overlappingResult is PlatformActionResultFailed)
+
+        transfer.cancel()
+        let firstResult = await firstDownload.value
+        XCTAssertTrue(firstResult is PlatformActionResultCancelled)
         HangingURLProtocol.started = nil
     }
 

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/platform/DownloadMetadata.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/platform/DownloadMetadata.kt
@@ -1,0 +1,113 @@
+package com.icecream.kwklasplus.core.platform
+
+object DownloadMetadata {
+    fun resolvedFileName(request: FileTransferRequest): String {
+        val guessed = request.suggestedFileName
+            ?: parseContentDispositionFileName(request.contentDisposition)
+            ?: fileNameFromUrl(request.url)
+            ?: "download"
+        return sanitizeDownloadFileName(ensureExtension(guessed, request.mimeType)) ?: "download"
+    }
+
+    fun looksLikePdf(mimeType: String?, contentDisposition: String?, url: String?): Boolean {
+        val mime = mimeType?.substringBefore(';')?.trim()?.lowercase()
+        if (mime == "application/pdf") return true
+        val name = parseContentDispositionFileName(contentDisposition) ?: url?.let(::fileNameFromUrl)
+        return name != null && extensionOf(name) == "pdf"
+    }
+
+    fun resolvedMimeType(fileNameOrUrl: String, mimeType: String?): String {
+        val trimmed = mimeType?.trim()?.takeIf { it.isNotEmpty() }
+        if (!trimmed.isNullOrEmpty() && trimmed != "application/octet-stream") {
+            return trimmed
+        }
+        val extension = extensionOf(fileNameOrUrl)
+        return MIME_BY_EXTENSION[extension] ?: "application/octet-stream"
+    }
+
+    fun parseContentDispositionFileName(header: String?): String? {
+        if (header.isNullOrBlank() || header.any(Char::isISOControl)) return null
+        RFC5987_FILE_NAME.find(header)?.let { match ->
+            return percentDecodeUtf8(match.groupValues[1].trim().trim('"'))
+                .takeIf { it.isNotBlank() }
+        }
+        QUOTED_FILE_NAME.find(header)?.let { match ->
+            return match.groupValues[1].takeIf { it.isNotBlank() }
+        }
+        BARE_FILE_NAME.find(header)?.let { match ->
+            return match.groupValues[1].trim().trim('"').takeIf { it.isNotBlank() }
+        }
+        return null
+    }
+
+    internal fun fileNameFromUrl(url: String): String? {
+        val path = url.substringAfter("://", missingDelimiterValue = url)
+            .substringAfter('/')
+            .substringBefore('?')
+            .substringBefore('#')
+        val last = path.substringAfterLast('/').trim()
+        return last.takeIf { it.isNotEmpty() }
+    }
+
+    private fun ensureExtension(fileName: String, mimeType: String?): String {
+        if (extensionOf(fileName).isNotEmpty()) return fileName
+        val extension = EXTENSION_BY_MIME[mimeType?.trim()?.lowercase()] ?: return fileName
+        return "$fileName.$extension"
+    }
+
+    private fun extensionOf(fileNameOrUrl: String): String {
+        val last = fileNameOrUrl.substringAfterLast('/').substringBefore('?').substringBefore('#')
+        if ('.' !in last) return ""
+        return last.substringAfterLast('.').lowercase()
+    }
+
+    private fun percentDecodeUtf8(value: String): String {
+        val bytes = ArrayList<Byte>(value.length)
+        var index = 0
+        while (index < value.length) {
+            val current = value[index]
+            if (current == '%' && index + 2 < value.length) {
+                val parsed = value.substring(index + 1, index + 3).toIntOrNull(16)
+                if (parsed != null) {
+                    bytes.add(parsed.toByte())
+                    index += 3
+                    continue
+                }
+            }
+            bytes.add(current.code.toByte())
+            index += 1
+        }
+        return bytes.toByteArray().decodeToString()
+    }
+
+    private val RFC5987_FILE_NAME =
+        Regex("""filename\*\s*=\s*UTF-8''([^;]+)""", RegexOption.IGNORE_CASE)
+    private val QUOTED_FILE_NAME =
+        Regex("""filename\s*=\s*"([^"]*)"""", RegexOption.IGNORE_CASE)
+    private val BARE_FILE_NAME =
+        Regex("""filename\s*=\s*([^;]+)""", RegexOption.IGNORE_CASE)
+
+    private val MIME_BY_EXTENSION = mapOf(
+        "pdf" to "application/pdf",
+        "hwp" to "application/x-hwp",
+        "hwpx" to "application/haansoft-hwpx",
+        "doc" to "application/msword",
+        "docx" to "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xls" to "application/vnd.ms-excel",
+        "xlsx" to "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "ppt" to "application/vnd.ms-powerpoint",
+        "pptx" to "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "txt" to "text/plain",
+        "csv" to "text/csv",
+        "jpg" to "image/jpeg",
+        "jpeg" to "image/jpeg",
+        "png" to "image/png",
+        "gif" to "image/gif",
+        "webp" to "image/webp",
+        "zip" to "application/zip",
+    )
+
+    private val EXTENSION_BY_MIME = MIME_BY_EXTENSION.entries
+        .groupBy({ it.value }, { it.key })
+        .mapValues { (_, extensions) -> extensions.first() }
+}

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicy.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicy.kt
@@ -37,8 +37,11 @@ class FileTransferPolicy(
     ): Boolean {
         // PDF는 iOS에서 인라인으로 연다. attachment/octet-stream이어도 공유 시트로 보내지 않는다.
         if (DownloadMetadata.looksLikePdf(mimeType, contentDisposition, url)) return false
-        val disposition = contentDisposition?.lowercase().orEmpty()
-        if ("attachment" in disposition || "filename" in disposition) return true
+        val dispositionType = contentDisposition
+            ?.substringBefore(';')
+            ?.trim()
+            ?.lowercase()
+        if (dispositionType == "attachment") return true
         val mime = mimeType?.substringBefore(';')?.trim()?.lowercase()
         if (mime != null && mime in SAVEABLE_DOCUMENT_MIME_TYPES) return true
         return !canShowMimeType

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicy.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicy.kt
@@ -6,7 +6,9 @@ sealed interface FileTransferValidation {
 }
 
 class FileTransferPolicy(
-    private val navigationPolicy: ExternalNavigationPolicy = ExternalNavigationPolicy(),
+    private val navigationPolicy: ExternalNavigationPolicy = ExternalNavigationPolicy(
+        maximumLength = DOWNLOAD_URL_MAXIMUM_LENGTH,
+    ),
 ) {
     fun validate(request: FileTransferRequest): FileTransferValidation {
         val destination = navigationPolicy.resolve(request.url)
@@ -15,27 +17,59 @@ class FileTransferPolicy(
         ) {
             return FileTransferValidation.Rejected
         }
-        val sanitizedName = request.suggestedFileName
-            ?.takeIf { it.isNotBlank() }
-            ?.map { character -> if (character in INVALID_FILE_NAME_CHARACTERS || character.isISOControl()) '_' else character }
-            ?.joinToString("")
-            ?.trim()
-            ?.take(180)
-            ?.takeIf(String::isNotEmpty)
-        val mimeType = request.mimeType
-            ?.trim()
-            ?.takeIf { '/' in it && !it.any(Char::isISOControl) }
         return FileTransferValidation.Accepted(
             request.copy(
-                suggestedFileName = sanitizedName,
-                mimeType = mimeType,
+                suggestedFileName = sanitizeDownloadFileName(request.suggestedFileName),
+                mimeType = request.mimeType
+                    ?.trim()
+                    ?.takeIf { '/' in it && !it.any(Char::isISOControl) },
                 userAgent = request.userAgent?.takeIf { !it.any(Char::isISOControl) },
                 contentDisposition = request.contentDisposition?.takeIf { !it.any(Char::isISOControl) },
             ),
         )
     }
 
-    private companion object {
-        const val INVALID_FILE_NAME_CHARACTERS = "\\/:*?\"<>|"
+    fun shouldTreatAsDownload(
+        mimeType: String?,
+        contentDisposition: String?,
+        canShowMimeType: Boolean,
+        url: String? = null,
+    ): Boolean {
+        // PDF는 iOS에서 인라인으로 연다. attachment/octet-stream이어도 공유 시트로 보내지 않는다.
+        if (DownloadMetadata.looksLikePdf(mimeType, contentDisposition, url)) return false
+        val disposition = contentDisposition?.lowercase().orEmpty()
+        if ("attachment" in disposition || "filename" in disposition) return true
+        val mime = mimeType?.substringBefore(';')?.trim()?.lowercase()
+        if (mime != null && mime in SAVEABLE_DOCUMENT_MIME_TYPES) return true
+        return !canShowMimeType
+    }
+
+    companion object {
+        fun create(): FileTransferPolicy = FileTransferPolicy()
     }
 }
+
+fun sanitizeDownloadFileName(name: String?): String? = name
+    ?.takeIf { it.isNotBlank() }
+    ?.map { character -> if (character in INVALID_DOWNLOAD_FILE_NAME_CHARACTERS || character.isISOControl()) '_' else character }
+    ?.joinToString("")
+    ?.trim()
+    ?.take(180)
+    ?.takeIf(String::isNotEmpty)
+
+private const val INVALID_DOWNLOAD_FILE_NAME_CHARACTERS = "\\/:*?\"<>|"
+private const val DOWNLOAD_URL_MAXIMUM_LENGTH = 16_384
+
+// 웹뷰가 인라인 렌더하지 못하는 문서 타입은 canShow/attachment 여부와 무관하게 다운로드로 처리한다.
+// PDF는 파일명·MIME으로 따로 식별해 인라인 표시한다.
+private val SAVEABLE_DOCUMENT_MIME_TYPES = setOf(
+    "application/x-hwp",
+    "application/haansoft-hwpx",
+    "application/msword",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-powerpoint",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/zip",
+)

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/platform/DownloadMetadataTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/platform/DownloadMetadataTest.kt
@@ -1,0 +1,79 @@
+package com.icecream.kwklasplus.core.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DownloadMetadataTest {
+    @Test
+    fun prefersSuggestedNameThenContentDispositionThenUrl() {
+        val fromSuggested = DownloadMetadata.resolvedFileName(
+            FileTransferRequest(
+                url = "https://klas.kw.ac.kr/a.bin",
+                suggestedFileName = "report.pdf",
+                mimeType = "application/pdf",
+                contentDisposition = """attachment; filename="other.hwp"""",
+            ),
+        )
+        assertEquals("report.pdf", fromSuggested)
+
+        val fromHeader = DownloadMetadata.resolvedFileName(
+            FileTransferRequest(
+                url = "https://klas.kw.ac.kr/a.bin",
+                suggestedFileName = null,
+                mimeType = null,
+                contentDisposition = """attachment; filename="과제:1.pdf"""",
+            ),
+        )
+        assertEquals("과제_1.pdf", fromHeader)
+
+        val fromUrl = DownloadMetadata.resolvedFileName(
+            FileTransferRequest(
+                url = "https://klas.kw.ac.kr/files/notice.zip?id=1",
+                suggestedFileName = null,
+                mimeType = null,
+            ),
+        )
+        assertEquals("notice.zip", fromUrl)
+    }
+
+    @Test
+    fun parsesRfc5987FileName() {
+        assertEquals(
+            "파일.pdf",
+            DownloadMetadata.parseContentDispositionFileName(
+                "attachment; filename*=UTF-8''%ED%8C%8C%EC%9D%BC.pdf",
+            ),
+        )
+    }
+
+    @Test
+    fun mapsKoreanOfficeMimeTypes() {
+        assertEquals("application/x-hwp", DownloadMetadata.resolvedMimeType("a.hwp", null))
+        assertEquals("application/haansoft-hwpx", DownloadMetadata.resolvedMimeType("a.hwpx", "application/octet-stream"))
+        assertEquals("application/pdf", DownloadMetadata.resolvedMimeType("a.bin", "application/pdf"))
+    }
+
+    @Test
+    fun detectsPdfFromMimeOrFileName() {
+        assertEquals(
+            true,
+            DownloadMetadata.looksLikePdf("application/pdf", null, "https://klas.kw.ac.kr/a.bin"),
+        )
+        assertEquals(
+            true,
+            DownloadMetadata.looksLikePdf(
+                "application/octet-stream",
+                """attachment; filename="컴퓨터구조_15주차_강의자료.pdf"""",
+                "https://klas.kw.ac.kr/std/lis/board/FileDownStd.do",
+            ),
+        )
+        assertEquals(
+            false,
+            DownloadMetadata.looksLikePdf(
+                "application/octet-stream",
+                """attachment; filename="note.hwp"""",
+                "https://klas.kw.ac.kr/std/lis/board/FileDownStd.do",
+            ),
+        )
+    }
+}

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicyTest.kt
@@ -82,6 +82,34 @@ class FileTransferPolicyTest {
     }
 
     @Test
+    fun respectsDispositionTypeInsteadOfFilenameParameter() {
+        assertEquals(
+            false,
+            policy.shouldTreatAsDownload(
+                mimeType = "text/plain",
+                contentDisposition = """inline; filename="note.txt"""",
+                canShowMimeType = true,
+            ),
+        )
+        assertEquals(
+            true,
+            policy.shouldTreatAsDownload(
+                mimeType = "text/plain",
+                contentDisposition = """attachment; filename="note.txt"""",
+                canShowMimeType = true,
+            ),
+        )
+        assertEquals(
+            true,
+            policy.shouldTreatAsDownload(
+                mimeType = "application/x-hwp",
+                contentDisposition = """inline; filename="note.hwp"""",
+                canShowMimeType = true,
+            ),
+        )
+    }
+
+    @Test
     fun rejectsNonWebAndControlCharacterUrls() {
         listOf("file:///data/file", "javascript:download()", "https://example.com\nfile:///x").forEach { url ->
             assertIs<FileTransferValidation.Rejected>(

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/platform/FileTransferPolicyTest.kt
@@ -24,6 +24,64 @@ class FileTransferPolicyTest {
     }
 
     @Test
+    fun acceptsLongHttpsDownloadUrls() {
+        val query = "enc=" + "a".repeat(4_000)
+        val result = policy.validate(
+            FileTransferRequest(
+                url = "https://klas.kw.ac.kr/std/lis/board/FileDownStd.do?$query",
+                suggestedFileName = "a.pdf",
+                mimeType = "application/pdf",
+            ),
+        )
+        assertIs<FileTransferValidation.Accepted>(result)
+    }
+
+    @Test
+    fun doesNotAutoDownloadPdfsEvenWhenAttachmentOrUnshowable() {
+        assertEquals(
+            false,
+            policy.shouldTreatAsDownload(
+                mimeType = "application/pdf",
+                contentDisposition = """inline; filename="컴퓨터구조_15주차_강의자료.pdf"""",
+                canShowMimeType = true,
+            ),
+        )
+        assertEquals(
+            false,
+            policy.shouldTreatAsDownload(
+                mimeType = "application/pdf",
+                contentDisposition = """attachment; filename="컴퓨터구조_15주차_강의자료.pdf"""",
+                canShowMimeType = true,
+            ),
+        )
+        assertEquals(
+            false,
+            policy.shouldTreatAsDownload(
+                mimeType = "application/octet-stream",
+                contentDisposition = """attachment; filename="컴퓨터구조_15주차_강의자료.pdf"""",
+                canShowMimeType = false,
+                url = "https://klas.kw.ac.kr/std/lis/board/FileDownStd.do?file=1",
+            ),
+        )
+        assertEquals(
+            true,
+            policy.shouldTreatAsDownload(
+                mimeType = "application/x-hwp",
+                contentDisposition = """attachment; filename="note.hwp"""",
+                canShowMimeType = true,
+            ),
+        )
+        assertEquals(
+            false,
+            policy.shouldTreatAsDownload(
+                mimeType = "text/html",
+                contentDisposition = null,
+                canShowMimeType = true,
+            ),
+        )
+    }
+
+    @Test
     fun rejectsNonWebAndControlCharacterUrls() {
         listOf("file:///data/file", "javascript:download()", "https://example.com\nfile:///x").forEach { url ->
             assertIs<FileTransferValidation.Rejected>(

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/platform/IosExternalNavigator.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/platform/IosExternalNavigator.kt
@@ -1,0 +1,41 @@
+package com.icecream.kwklasplus.core.platform
+
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+
+fun interface IosUrlOpener {
+    fun open(url: NSURL): Boolean
+}
+
+class IosExternalNavigator(
+    private val opener: IosUrlOpener,
+) : ExternalNavigator {
+    override suspend fun open(destination: ExternalDestination): PlatformActionResult = openNow(destination)
+
+    fun openNow(destination: ExternalDestination): PlatformActionResult {
+        val raw = when (destination) {
+            is ExternalDestination.Web -> destination.url
+            is ExternalDestination.Email -> "mailto:${destination.address}"
+            is ExternalDestination.Telephone -> "tel:${destination.number}"
+            is ExternalDestination.PlatformUri -> return PlatformActionResult.Unsupported
+        }
+        val url = NSURL.URLWithString(raw) ?: return PlatformActionResult.Failed("invalid_external_destination")
+        return if (opener.open(url)) {
+            PlatformActionResult.Success
+        } else {
+            PlatformActionResult.Failed("external_navigation_denied")
+        }
+    }
+
+    fun openValidated(rawValue: String): PlatformActionResult =
+        when (val resolution = ExternalNavigationPolicy().resolve(rawValue)) {
+            is ExternalNavigationResolution.Allowed -> openNow(resolution.destination)
+            ExternalNavigationResolution.Rejected -> PlatformActionResult.Failed("invalid_external_destination")
+        }
+
+    companion object {
+        fun system(): IosExternalNavigator = IosExternalNavigator { url ->
+            UIApplication.sharedApplication.openURL(url)
+        }
+    }
+}

--- a/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/platform/IosExternalNavigatorTest.kt
+++ b/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/platform/IosExternalNavigatorTest.kt
@@ -1,0 +1,58 @@
+package com.icecream.kwklasplus.core.platform
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class IosExternalNavigatorTest {
+    @Test
+    fun opensAllowedDestinationsAndRejectsMaliciousSchemes() {
+        val opened = mutableListOf<String>()
+        val navigator = IosExternalNavigator { url ->
+            opened += requireNotNull(url.absoluteString)
+            true
+        }
+
+        assertEquals(
+            PlatformActionResult.Success,
+            navigator.openValidated("https://klas.kw.ac.kr/std/file"),
+        )
+        assertEquals(
+            PlatformActionResult.Success,
+            navigator.openValidated("mailto:help@example.com"),
+        )
+        assertEquals(
+            PlatformActionResult.Success,
+            navigator.openValidated("tel:+82-2-123-4567"),
+        )
+
+        listOf(
+            "javascript:alert(1)",
+            "intent://settings",
+            "file:///tmp/secret",
+            "https://user@example.com",
+        ).forEach { raw ->
+            assertIs<PlatformActionResult.Failed>(navigator.openValidated(raw))
+        }
+
+        assertEquals(
+            listOf(
+                "https://klas.kw.ac.kr/std/file",
+                "mailto:help@example.com",
+                "tel:+82-2-123-4567",
+            ),
+            opened,
+        )
+        assertTrue(opened.none { it.startsWith("javascript") || it.startsWith("intent") || it.startsWith("file:") })
+    }
+
+    @Test
+    fun platformUriIsUnsupported() {
+        val navigator = IosExternalNavigator { true }
+        assertEquals(
+            PlatformActionResult.Unsupported,
+            navigator.openNow(ExternalDestination.PlatformUri("custom://x")),
+        )
+    }
+}


### PR DESCRIPTION
Stacked on #13 

## Summary

M6-010 iOS 다운로드, 파일 선택, 외부 이동을 구현합니다. 공통 FileTransferPolicy, DownloadMetadata, ExternalNavigationPolicy는 Android와 같은 계약을 쓰고, WKWebView에서만 가능한 PDF 인라인 미리보기는 iOS 어댑터가 처리합니다. 
Android WebView는 PDF를 렌더하지 못해 저장/공유로 넘기지만, iOS WKWebView는 표시 가능한 PDF를 웹뷰에서 엽니다. attachment이거나 octet-stream인 PDF는 받아서 로컬 파일로 연 뒤 공유할 수 있습니다.

## Changes

- 공통: HTTPS 다운로드 URL 검증, MIME와 파일명 sanitize, Content-Disposition type 판정. attachment만 강제 다운로드하고, inline; filename=...은 표시 가능 MIME이면 렌더링
- 다운로드: WKHTTPCookieStore의 매칭 쿠키를 URLSession에 붙여 받아 임시 디렉터리에 저장. PDF는 웹뷰, 그 외는 공유 시트. 진행 중 다운로드는 single-flight로 막고, 취소 완료 전에는 재진입하지 않음
- 업로드: WKUIDelegate.runOpenPanelWith에서 UIDocumentPicker로 단일/다중 선택과 취소를 처리
- 외부 이동: IosExternalNavigator가 http, https, mailto, tel만 열고 javascript, intent, file 등은 거부
- 화면: Home, Lecture, Link WebView에 다운로드 진행과 오류 오버레이를 연결

## Test plan

- ./gradlew :shared:testAndroidHostTest :shared:iosSimulatorArm64Test --tests 'com.icecream.kwklasplus.core.platform.*'
- xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test -only-testing:iosAppTests/IosFilePortsTests
- 세션이 필요한 첨부파일 다운로드에서 진행률, 취소, 공유를 확인
- 인라인 PDF는 웹뷰 미리보기, attachment PDF는 받아서 웹뷰에 연 뒤 공유
- 파일 선택 단일, 다중, 취소
- mailto, tel, https 외부 열기와 악성 scheme 거부

https://github.com/user-attachments/assets/8ad31ef8-1e3f-4689-b3cc-c92e603a126d

## Notes

파일 업로드 기능은 제 실 계정에서 업로드할 수 있는 과제가 존재하지 않아서 아직 미완으로 두었습니다. 추후에 테스트가 가능할 때 테스트 후 완료처리 해두도록 하겠습니다. 