### PR TITLE
feat: M6-011 iOS WKWebView safe area·viewport와 overlay 호스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .kotlin
 .gradle
 **/build/
+.build/
 xcuserdata
 !src/**/build/
 local.properties

--- a/TASKS.md
+++ b/TASKS.md
@@ -129,6 +129,7 @@
   - 작업: Home·Lecture·Board·LecturePlan·Link·Settings command 중 해당 화면에 필요한 navigation/modal/reload/callback 연결
   - 완료 기준: F-007~F-016 P0 경로에서 `KlasNativeBridge.*` 호출과 Native → Web callback이 Android와 동일한 결과를 생성
   - 검증: 앱 Web + 신 iOS 조합의 탭·back·게시판·강의·과제 링크·학기 선택·modal 회귀
+  - 후속: 홈 공지 `openPage(www.kw.ac.kr)`는 Link holder 인앱 http(s) 모드로 Safari 대신 WKWebView 로드. `IosFilePortsTests` in-app web, `IosHomeHostTests` `testUniversityNoticeOpenPagePushesInAppLink`
 - [ ] **M6-010 (P1, L)** WKWebView 다운로드·파일 선택·외부 이동
   - Depends on: M6-009
   - 작업: WKDownload/URLSession, document/photo picker, share sheet, `UIApplication.open`을 공통 요청·URL 정책에 연결

--- a/TASKS.md
+++ b/TASKS.md
@@ -134,10 +134,11 @@
   - 작업: WKDownload/URLSession, document/photo picker, share sheet, `UIApplication.open`을 공통 요청·URL 정책에 연결
   - 완료 기준: cookie가 필요한 다운로드, MIME·파일명, 단일/다중 선택, 취소, mailto/tel/https와 악성 scheme 거부
   - 남은 일: 파일 업로드(`UIDocumentPicker`)는 계약 테스트만 통과. 실계정 KLAS 업로드 경로 검증 후 완료 처리
-- [ ] **M6-011 (P1, M)** WKWebView 컨테이너의 iOS UI 환경 대응
+- [x] **M6-011 (P1, M)** WKWebView 컨테이너의 iOS UI 환경 대응
   - Depends on: M6-009
   - 작업: SwiftUI theme, safe area, 키보드·viewport, iPhone/iPad 회전과 Dynamic Type/VoiceOver focus 처리
   - 완료 기준: Web content와 Native overlay가 compact/regular, 세로/가로, 키보드 표시 상태에서 가려지거나 중복 재생성되지 않음
+  - 구현: persistent WebView layout/viewport policy, screen-level overlay host, Dynamic Type·accessibility focus, iOS UI test fixture/target을 추가
 
 ### M7 — iOS 네이티브 기능 구현
 

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -30,7 +30,7 @@
 | F-013 | 강의계획서 | typed Web route | typed Web route | P1 | Parity | iOS M6-009: LecturePlan surface + `receivedData` 2인자 |
 | F-014 | 게시판 목록/상세 | Web route + file ports | 동일 | P0 | Parity | iOS M6-009: Board surface + `receivedData` 4인자 |
 | F-015 | 과제/퀴즈/시험 링크 | KLAS Web route | 동일 | P0 | Parity | iOS M6-009: Task 화면(브리지 없음) localStorage bootstrap. 영상 URL은 M7 stub |
-| F-016 | 일반 링크 | typed navigation + Android adapter | iOS navigation adapter | P1 | Parity | iOS M6-009: `AppRouteFactory` + Link host |
+| F-016 | 일반 링크 | typed navigation + Android adapter | iOS navigation adapter | P1 | Parity | iOS M6-009: `AppRouteFactory` + Link host. `openPage`는 `www.kw.ac.kr` 공지처럼 비앱 https도 Link WKWebView에 로드한다. 이후 같은 화면의 http(s)는 인앱에 남긴다(Android LinkView의 이후 비신뢰 클릭 Chrome 이동과 승인 차이). `openExternalPage`만 Safari |
 | F-017 | 온라인 강의 재생 | Android player/PIP host | iOS player host | P0 | Parity | 재생·seek·speed·진도 포함 |
 | F-018 | PIP | Android native | AVKit/WK media | P1 | Parity | remote action·상태 복구 포함 |
 | F-019 | QR 출석 | Android scanner port | AVFoundation/VisionKit port | P0 | Parity | 성공·실패·취소·중복 실행 포함 |
@@ -41,7 +41,7 @@
 | F-024 | 설정/테마/버전 | 공통 Web/Compose + settings | 동일 | P1 | Parity | 재시작 persistence 포함. iOS `KlasTheme` 토큰은 Android `values`/`values-night` light·dark 쌍 |
 | F-025 | 다운로드 | Android DownloadManager/SAF | URLSession/files/share | P1 | Parity | cookie·MIME·filename·취소 포함. `inline` 파일명은 표시 가능 MIME이면 렌더링하고 `attachment`만 강제 다운로드. iOS는 single-flight로 중복 요청과 취소 완료 전 재진입을 거부 |
 | F-026 | 파일 선택/업로드 | Activity Result adapter | document/photo picker | P1 | Parity | 단일·다중·MIME·취소 포함. iOS M6-010: `UIDocumentPicker`와 계약 테스트는 있음. 실계정 업로드 검증은 후속 |
-| F-027 | 외부 링크/mailto | allowlist + Android Intent | allowlist + UIApplication | P1 | Parity | 악성 URL 거부 포함 |
+| F-027 | 외부 링크/mailto | allowlist + Android Intent | allowlist + UIApplication | P1 | Parity | 악성 URL 거부 포함. Home 등 제품 surface는 비신뢰 https를 Safari로 보내고, Link `openPage` 화면만 인앱 http(s)를 허용한다 |
 | F-028 | 햅틱 | semantic haptic adapter | UIKit feedback adapter | P2 | Parity | legacy 14개 이름 보존 |
 | F-029 | Android 인앱 업데이트 | Play Core legacy 경로 유지 | Approved difference | P2 | Parity | Android 전용 기능 |
 | F-030 | 폰 세로/태블릿 회전 | window size/orientation policy | iOS orientation policy | P1 | Parity | 폰·태블릿·멀티윈도우 포함 |

--- a/docs/MIGRATION_ARCHITECTURE.md
+++ b/docs/MIGRATION_ARCHITECTURE.md
@@ -222,6 +222,8 @@ KLAS 인증/학기/시간표/마감일/출석, 도서관, 학생증 QR와 강의
 
 WebView 인스턴스를 화면 재구성 때마다 만들지 않는다. 화면 수명주기와 분리된 holder/controller로 유지하고, 명시적인 dispose에서 브리지 handler와 delegate를 해제해 누수와 중복 콜백을 막는다.
 
+iOS의 WebView container는 UIKit 자동 content inset을 끄고 `container` safe area의 bottom만 선택적으로 무시한다. keyboard safe area는 무시하지 않아 WKWebView frame이 IME에 맞춰 줄어들게 하며, `visualViewport` resize/scroll 이벤트는 fixed navigation과 modal이 viewport 변화를 관찰할 수 있도록 document-end policy script로 전달한다. Native toolbar·sheet·toast·download overlay는 Web content와 별도로 SwiftUI safe area 안에 배치한다. 회전과 trait 변경은 holder identity를 바꾸지 않으며, native overlay가 표시되는 동안 뒤의 WebView는 hit-test와 VoiceOver 접근성 트리에서 제외한다.
+
 ### 4.5 버전형 JavaScript 브리지
 
 Web이 다음 envelope를 갖는 Bridge v1 프로토콜을 우선 사용한다.

--- a/iosApp/M6-011.xctestplan
+++ b/iosApp/M6-011.xctestplan
@@ -1,0 +1,66 @@
+{
+  "configurations" : [
+    {
+      "id" : "M6011-FIXTURE",
+      "name" : "M6-011 Fixture",
+      "options" : {
+        "commandLineArgumentEntries" : [
+          {
+            "argument" : "-m6011-ui-test",
+            "enabled" : true
+          }
+        ],
+        "environmentVariableEntries" : [
+          {
+            "key" : "M6011_DYNAMIC_TYPE",
+            "value" : "accessibility3",
+            "enabled" : true
+          }
+        ],
+        "testTimeoutsEnabled" : true
+      }
+    },
+    {
+      "id" : "M6011-ACCESSIBILITY",
+      "name" : "M6-011 Accessibility XXXL",
+      "options" : {
+        "commandLineArgumentEntries" : [
+          {
+            "argument" : "-m6011-ui-test",
+            "enabled" : true
+          }
+        ],
+        "environmentVariableEntries" : [
+          {
+            "key" : "M6011_DYNAMIC_TYPE",
+            "value" : "accessibility5",
+            "enabled" : true
+          }
+        ],
+        "testTimeoutsEnabled" : true
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "testTimeoutsEnabled" : true
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:iosApp.xcodeproj",
+        "identifier" : "A11B0005A5ED6EA33B3393BB",
+        "name" : "iosAppTests"
+      }
+    },
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:iosApp.xcodeproj",
+        "identifier" : "A11C0005A5ED6EA33B3393BB",
+        "name" : "iosAppUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -14,11 +14,20 @@
 			remoteGlobalIDString = 5C51A9D6A5ED6EA33B3393BB;
 			remoteInfo = iosApp;
 		};
+		A11C0001A5ED6EA33B3393BB /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B3F43505C841AEB9980E56A1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5C51A9D6A5ED6EA33B3393BB;
+			remoteInfo = iosApp;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		F6F71C8CC4FEF251D6AD8B93 /* kw-klas-plus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "kw-klas-plus.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A11B0002A5ED6EA33B3393BB /* iosAppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A11C0002A5ED6EA33B3393BB /* iosAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = iosAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A11C000DA5ED6EA33B3393BB /* M6-011.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text.xctestplan; path = "M6-011.xctestplan"; sourceTree = "<group>"; };
+		F6F71C8CC4FEF251D6AD8B93 /* kw-klas-plus.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "kw-klas-plus.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -45,6 +54,11 @@
 			path = iosAppTests;
 			sourceTree = "<group>";
 		};
+		A11C0003A5ED6EA33B3393BB /* iosAppUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = iosAppUITests;
+			sourceTree = "<group>";
+		};
 		DF52283B59D2B33DAABB1CB8 /* Configuration */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Configuration;
@@ -67,6 +81,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A11C0004A5ED6EA33B3393BB /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -75,6 +96,7 @@
 			children = (
 				F6F71C8CC4FEF251D6AD8B93 /* kw-klas-plus.app */,
 				A11B0002A5ED6EA33B3393BB /* iosAppTests.xctest */,
+				A11C0002A5ED6EA33B3393BB /* iosAppUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -85,6 +107,8 @@
 				DF52283B59D2B33DAABB1CB8 /* Configuration */,
 				477D2151B5EFFBC8D338B575 /* iosApp */,
 				A11B0003A5ED6EA33B3393BB /* iosAppTests */,
+				A11C0003A5ED6EA33B3393BB /* iosAppUITests */,
+				A11C000DA5ED6EA33B3393BB /* M6-011.xctestplan */,
 				BD53EF4F6008D2C1AA37C0C0 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -138,6 +162,29 @@
 			productReference = A11B0002A5ED6EA33B3393BB /* iosAppTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		A11C0005A5ED6EA33B3393BB /* iosAppUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A11C0009A5ED6EA33B3393BB /* Build configuration list for PBXNativeTarget "iosAppUITests" */;
+			buildPhases = (
+				A11C0006A5ED6EA33B3393BB /* Sources */,
+				A11C0004A5ED6EA33B3393BB /* Frameworks */,
+				A11C0007A5ED6EA33B3393BB /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A11C0008A5ED6EA33B3393BB /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A11C0003A5ED6EA33B3393BB /* iosAppUITests */,
+			);
+			name = iosAppUITests;
+			packageProductDependencies = (
+			);
+			productName = iosAppUITests;
+			productReference = A11C0002A5ED6EA33B3393BB /* iosAppUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -152,6 +199,10 @@
 						CreatedOnToolsVersion = 16.2;
 					};
 					A11B0005A5ED6EA33B3393BB = {
+						CreatedOnToolsVersion = 16.2;
+						TestTargetID = 5C51A9D6A5ED6EA33B3393BB;
+					};
+					A11C0005A5ED6EA33B3393BB = {
 						CreatedOnToolsVersion = 16.2;
 						TestTargetID = 5C51A9D6A5ED6EA33B3393BB;
 					};
@@ -173,6 +224,7 @@
 			targets = (
 				5C51A9D6A5ED6EA33B3393BB /* iosApp */,
 				A11B0005A5ED6EA33B3393BB /* iosAppTests */,
+				A11C0005A5ED6EA33B3393BB /* iosAppUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -186,6 +238,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		A11B0007A5ED6EA33B3393BB /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A11C0007A5ED6EA33B3393BB /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -231,6 +290,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A11C0006A5ED6EA33B3393BB /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -238,6 +304,11 @@
 			isa = PBXTargetDependency;
 			target = 5C51A9D6A5ED6EA33B3393BB /* iosApp */;
 			targetProxy = A11B0001A5ED6EA33B3393BB /* PBXContainerItemProxy */;
+		};
+		A11C0008A5ED6EA33B3393BB /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5C51A9D6A5ED6EA33B3393BB /* iosApp */;
+			targetProxy = A11C0001A5ED6EA33B3393BB /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -363,6 +434,92 @@
 			};
 			name = Release;
 		};
+		A11B000AA5ED6EA33B3393BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.icecream.kwklasplus.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/kw-klas-plus.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/kw-klas-plus";
+			};
+			name = Debug;
+		};
+		A11B000BA5ED6EA33B3393BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = arm64;
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.icecream.kwklasplus.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/kw-klas-plus.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/kw-klas-plus";
+			};
+			name = Release;
+		};
+		A11C000AA5ED6EA33B3393BB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.icecream.kwklasplus.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iosApp;
+			};
+			name = Debug;
+		};
+		A11C000BA5ED6EA33B3393BB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "${TEAM_ID}";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.icecream.kwklasplus.uitests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = iosApp;
+			};
+			name = Release;
+		};
 		B5FF090896BF667469217227 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -421,56 +578,6 @@
 			};
 			name = Release;
 		};
-		A11B000AA5ED6EA33B3393BB /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = arm64;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.icecream.kwklasplus.tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/kw-klas-plus.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/kw-klas-plus";
-			};
-			name = Debug;
-		};
-		A11B000BA5ED6EA33B3393BB /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = arm64;
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "${TEAM_ID}";
-				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.icecream.kwklasplus.tests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/kw-klas-plus.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/kw-klas-plus";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -483,20 +590,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		A5D6CDE971D31B04A1BC6E75 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				B5FF090896BF667469217227 /* Debug */,
-				D7E0DC7D25D75AA652830901 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		A11B0009A5ED6EA33B3393BB /* Build configuration list for PBXNativeTarget "iosAppTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				A11B000AA5ED6EA33B3393BB /* Debug */,
 				A11B000BA5ED6EA33B3393BB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A11C0009A5ED6EA33B3393BB /* Build configuration list for PBXNativeTarget "iosAppUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A11C000AA5ED6EA33B3393BB /* Debug */,
+				A11C000BA5ED6EA33B3393BB /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A5D6CDE971D31B04A1BC6E75 /* Build configuration list for PBXNativeTarget "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B5FF090896BF667469217227 /* Debug */,
+				D7E0DC7D25D75AA652830901 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/iosApp/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -33,6 +33,20 @@
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A11C0005A5ED6EA33B3393BB"
+               BuildableName = "iosAppUITests.xctest"
+               BlueprintName = "iosAppUITests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -50,6 +64,17 @@
                BlueprintIdentifier = "A11B0005A5ED6EA33B3393BB"
                BuildableName = "iosAppTests.xctest"
                BlueprintName = "iosAppTests"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A11C0005A5ED6EA33B3393BB"
+               BuildableName = "iosAppUITests.xctest"
+               BlueprintName = "iosAppUITests"
                ReferencedContainer = "container:iosApp.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/iosApp/iosApp/BoardView.swift
+++ b/iosApp/iosApp/BoardView.swift
@@ -100,7 +100,7 @@ struct BoardView: View {
     }
 
     var body: some View {
-        PushedWebStack(holder: model.holder, isLoading: model.holder.isLoading) {
+        PushedWebStack(holder: model.holder) {
             if model.holder.goBack() { return }
             dismiss()
         }

--- a/iosApp/iosApp/BoardView.swift
+++ b/iosApp/iosApp/BoardView.swift
@@ -100,7 +100,7 @@ struct BoardView: View {
     }
 
     var body: some View {
-        PushedWebStack(holder: model.holder) {
+        PushedWebStack(holder: model.holder, showsPageLoading: false) {
             if model.holder.goBack() { return }
             dismiss()
         }

--- a/iosApp/iosApp/DownloadOverlay.swift
+++ b/iosApp/iosApp/DownloadOverlay.swift
@@ -44,3 +44,28 @@ struct DownloadProgressOverlay: View {
         }
     }
 }
+
+extension View {
+    func webDownloadOverlay(_ holder: WebViewHolder) -> some View {
+        overlay {
+            if let progress = holder.downloadProgress {
+                DownloadProgressOverlay(
+                    fileName: progress.fileName,
+                    fraction: progress.fraction,
+                    onCancel: { holder.cancelDownload() }
+                )
+            }
+        }
+        .alert(
+            "다운로드 실패",
+            isPresented: Binding(
+                get: { holder.downloadErrorMessage != nil },
+                set: { if !$0 { holder.clearDownloadError() } }
+            )
+        ) {
+            Button("확인") { holder.clearDownloadError() }
+        } message: {
+            Text(holder.downloadErrorMessage ?? "")
+        }
+    }
+}

--- a/iosApp/iosApp/DownloadOverlay.swift
+++ b/iosApp/iosApp/DownloadOverlay.swift
@@ -1,4 +1,3 @@
-import Shared
 import SwiftUI
 
 struct DownloadProgressState: Equatable {
@@ -10,6 +9,7 @@ struct DownloadProgressOverlay: View {
     let fileName: String
     let fraction: Double
     let onCancel: () -> Void
+    @AccessibilityFocusState private var focusedCancel: Bool
 
     var body: some View {
         ZStack {
@@ -19,42 +19,28 @@ struct DownloadProgressOverlay: View {
                     .font(.headline)
                     .multilineTextAlignment(.center)
                     .lineLimit(2)
+                    .minimumScaleFactor(0.7)
+                    .fixedSize(horizontal: false, vertical: true)
                 if fraction > 0 {
                     ProgressView(value: min(max(fraction, 0), 1))
                 } else {
                     ProgressView()
                 }
                 Button("취소", action: onCancel)
+                    .accessibilityFocused($focusedCancel)
             }
             .padding(24)
             .frame(maxWidth: 320)
             .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .padding(16)
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
         .accessibilityIdentifier("download_progress_overlay")
-    }
-}
-
-extension View {
-    func webDownloadOverlay(_ holder: WebViewHolder) -> some View {
-        overlay {
-            if let progress = holder.downloadProgress {
-                DownloadProgressOverlay(
-                    fileName: progress.fileName,
-                    fraction: progress.fraction,
-                    onCancel: { holder.cancelDownload() }
-                )
+        .onAppear {
+            DispatchQueue.main.async {
+                focusedCancel = true
             }
-        }
-        .alert(
-            "다운로드 실패",
-            isPresented: Binding(
-                get: { holder.downloadErrorMessage != nil },
-                set: { if !$0 { holder.clearDownloadError() } }
-            )
-        ) {
-            Button("확인") { holder.clearDownloadError() }
-        } message: {
-            Text(holder.downloadErrorMessage ?? "")
         }
     }
 }

--- a/iosApp/iosApp/HomeOverlays.swift
+++ b/iosApp/iosApp/HomeOverlays.swift
@@ -55,8 +55,8 @@ struct HomeOverlayModifier: ViewModifier {
                 .preferredColorScheme(coordinator.colorScheme)
             }
             .overlay(alignment: .bottom) {
-                GeometryReader { proxy in
-                    if let toast = coordinator.toastMessage {
+                if let toast = coordinator.toastMessage {
+                    GeometryReader { proxy in
                         Text(toast)
                             .font(.subheadline)
                             .foregroundStyle(KlasTheme.onSurface)
@@ -74,6 +74,7 @@ struct HomeOverlayModifier: ViewModifier {
                             )
                             .accessibilityIdentifier("home_toast")
                     }
+                    .allowsHitTesting(false)
                 }
             }
     }

--- a/iosApp/iosApp/HomeOverlays.swift
+++ b/iosApp/iosApp/HomeOverlays.swift
@@ -55,18 +55,25 @@ struct HomeOverlayModifier: ViewModifier {
                 .preferredColorScheme(coordinator.colorScheme)
             }
             .overlay(alignment: .bottom) {
-                if let toast = coordinator.toastMessage {
-                    Text(toast)
-                        .font(.subheadline)
-                        .foregroundStyle(KlasTheme.onSurface)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(
-                            Capsule(style: .continuous)
-                                .fill(KlasTheme.surfaceContainerHigh)
-                        )
-                        .padding(.bottom, 24)
-                        .accessibilityIdentifier("home_toast")
+                GeometryReader { proxy in
+                    if let toast = coordinator.toastMessage {
+                        Text(toast)
+                            .font(.subheadline)
+                            .foregroundStyle(KlasTheme.onSurface)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 10)
+                            .background(
+                                Capsule(style: .continuous)
+                                    .fill(KlasTheme.surfaceContainerHigh)
+                            )
+                            .padding(.bottom, max(24, proxy.safeAreaInsets.bottom + 8))
+                            .frame(
+                                maxWidth: .infinity,
+                                maxHeight: .infinity,
+                                alignment: .bottom
+                            )
+                            .accessibilityIdentifier("home_toast")
+                    }
                 }
             }
     }

--- a/iosApp/iosApp/HomeView.swift
+++ b/iosApp/iosApp/HomeView.swift
@@ -11,9 +11,16 @@ struct HomeView: View {
                 Color.clear
             } else {
                 WebViewContainer(webView: holder.webView)
-                    .ignoresSafeArea(edges: .bottom)
-                    .ignoresSafeArea(.keyboard)
+                    .webSurfaceLayout()
                     .accessibilityLabel("KLAS+")
+                    .accessibilityHidden(
+                        coordinator.isPageLoading
+                            || coordinator.showYearHakgiPicker
+                            || coordinator.showOptionsMenu
+                            || coordinator.showDatePicker
+                            || holder.javaScriptAlertMessage != nil
+                            || holder.downloadProgress != nil
+                    )
             }
             if coordinator.isPageLoading {
                 KlasLoadingView(message: "불러오는 중")
@@ -35,25 +42,6 @@ struct HomeView: View {
 }
 
 extension View {
-    func webJavaScriptAlert(_ holder: WebViewHolder, enabled: Bool = true) -> some View {
-        alert(
-            "안내",
-            isPresented: Binding(
-                get: { enabled && holder.javaScriptAlertMessage != nil },
-                set: { if !$0 { holder.confirmJavaScriptAlert() } }
-            )
-        ) {
-            Button("확인") { holder.confirmJavaScriptAlert() }
-        } message: {
-            Text(holder.javaScriptAlertMessage ?? "")
-        }
-        .onReceive(holder.$javaScriptAlertMessage) { message in
-            if !enabled, message != nil {
-                holder.confirmJavaScriptAlert()
-            }
-        }
-    }
-
     func homeOverlays(_ coordinator: HomeCoordinator) -> some View {
         modifier(HomeOverlayModifier(coordinator: coordinator))
     }

--- a/iosApp/iosApp/KlasTheme.swift
+++ b/iosApp/iosApp/KlasTheme.swift
@@ -32,7 +32,7 @@ enum KlasTheme {
     static let registerURL = URL(string: "https://klas.kw.ac.kr/usr/cmn/login/modal/UserFrstModPwdPage.do")!
 }
 
-enum AppWindowWidthClass {
+enum AppWindowWidthClass: Equatable {
     case compact, medium, expanded
 
     static func classify(width: CGFloat) -> AppWindowWidthClass {
@@ -81,7 +81,8 @@ struct KlasInverseButtonStyle: ButtonStyle {
             .font(.body.weight(.semibold))
             .foregroundStyle(enabled ? KlasTheme.inverseButtonContent : KlasTheme.disabledContent)
             .frame(maxWidth: .infinity)
-            .frame(height: KlasTheme.buttonHeight)
+            .frame(minHeight: KlasTheme.buttonHeight)
+            .padding(.vertical, 4)
             .background(
                 RoundedRectangle(cornerRadius: KlasTheme.controlCornerRadius, style: .continuous)
                     .fill(enabled ? KlasTheme.inversePrimary : KlasTheme.disabledContainer)
@@ -104,13 +105,16 @@ struct KlasTextLinkButtonStyle: ButtonStyle {
 }
 
 struct KlasSelectionRowButtonStyle: ButtonStyle {
+    @ScaledMetric(relativeTo: .footnote) private var optionFontSize: CGFloat = 14
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .font(.system(size: 14, weight: .medium))
+            .font(.system(size: optionFontSize, weight: .medium))
             .foregroundStyle(KlasTheme.onSurfaceVariant)
             .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .frame(height: KlasTheme.buttonHeight)
+            .frame(minHeight: KlasTheme.buttonHeight)
+            .padding(.vertical, 4)
             .background(
                 RoundedRectangle(cornerRadius: KlasTheme.controlCornerRadius, style: .continuous)
                     .fill(configuration.isPressed ? KlasTheme.primary.opacity(0.12) : Color.clear)

--- a/iosApp/iosApp/LecturePlanView.swift
+++ b/iosApp/iosApp/LecturePlanView.swift
@@ -62,7 +62,7 @@ struct LecturePlanView: View {
     }
 
     var body: some View {
-        PushedWebStack(holder: model.holder, isLoading: model.holder.isLoading) {
+        PushedWebStack(holder: model.holder) {
             if model.holder.goBack() { return }
             dismiss()
         }

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -126,9 +126,10 @@ final class LectureScreenModel: ObservableObject {
 
     /// Android는 `Frame.do` 로드 시 `KlasWebAutomationScripts.openLecture(...)`를 즉시 한 번만 호출한다.
     /// (Android WebView의 `onPageFinished`는 페이지 스크립트 초기화가 끝난 뒤 불린다.)
-    /// 반면 WKWebView의 `didFinish`는 `appModule`이 바인딩되기 전에 발생할 수 있으므로,
-    /// `openLectureWhenReady`가 `appModule.goLctrum`이 준비될 때까지 폴링한 뒤 호출한다.
-    /// `didOpenLecture`로 화면당 1회만 실행되도록 보장한다.
+    /// WKWebView `didFinish`는 `appModule.goLctrum`이 함수로만 존재하고 내부 상태가 덜 준비된
+    /// 시점에 올 수 있다. 그때 호출하면 KLAS가 `오류가 발생하였습니다.` alert를 띄운다.
+    /// `openLectureWhenReady`는 함수가 생길 때까지 기다린 뒤 호출하고, 그 부트스트랩 alert가
+    /// 나면 삼키고 재시도한다. `didOpenLecture`로 화면당 주입은 1회로 제한한다.
     private func openLectureIfNeeded() {
         guard !didOpenLecture else { return }
         didOpenLecture = true
@@ -252,14 +253,31 @@ struct LectureView: View {
     var body: some View {
         ZStack {
             WebViewContainer(webView: model.uiHolder.webView)
+                .webSurfaceLayout()
+                .accessibilityHidden(
+                    model.isLoading
+                        || model.showingKlas
+                        || model.uiHolder.javaScriptAlertMessage != nil
+                        || model.klasHolder.javaScriptAlertMessage != nil
+                        || model.uiHolder.downloadProgress != nil
+                        || model.klasHolder.downloadProgress != nil
+                )
             WebViewContainer(webView: model.klasHolder.webView)
+                .webSurfaceLayout()
                 .opacity(model.showingKlas ? 1 : 0)
                 .allowsHitTesting(model.showingKlas)
+                .accessibilityHidden(
+                    model.isLoading
+                        || !model.showingKlas
+                        || model.uiHolder.javaScriptAlertMessage != nil
+                        || model.klasHolder.javaScriptAlertMessage != nil
+                        || model.uiHolder.downloadProgress != nil
+                        || model.klasHolder.downloadProgress != nil
+                )
             if model.isLoading {
                 KlasLoadingView(message: "불러오는 중")
             }
         }
-        .ignoresSafeArea(edges: .bottom)
         .navigationTitle(model.subjectName)
         .navigationBarTitleDisplayMode(.inline)
         .navigationBarBackButtonHidden(true)
@@ -287,10 +305,12 @@ struct LectureView: View {
                 }
             }
         }
-        .webJavaScriptAlert(model.uiHolder)
-        .webJavaScriptAlert(model.klasHolder, enabled: model.showingKlas)
-        .webDownloadOverlay(model.uiHolder)
-        .webDownloadOverlay(model.klasHolder)
+        .webJavaScriptAlert(
+            model.uiHolder,
+            model.klasHolder,
+            activeSecondary: model.showingKlas
+        )
+        .webDownloadOverlay(model.uiHolder, model.klasHolder)
         .onReceive(model.klasHolder.$navigationState) { state in
             model.handleKlasNavigation(state)
         }

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -17,8 +17,8 @@ final class LectureScreenModel: ObservableObject {
     private var host: LectureHostAdapter
     private var boardNoticePath = ""
     private var boardPdsPath = ""
-    private var didOpenLecture = false
-    private var isOpeningLecture = false
+    private(set) var didOpenLecture = false
+    private(set) var isOpeningLecture = false
     private var boardPathCollectTask: Task<Void, Never>?
     private var openLectureRetryTask: Task<Void, Never>?
     private var openLectureWindowTask: Task<Void, Never>?
@@ -46,6 +46,9 @@ final class LectureScreenModel: ObservableObject {
             handler: IosLectureLegacyBridgeCommandHandler(host: host)
         )
         host.model = self
+        klasHolder.onWebContentProcessDidTerminate = { [weak self] in
+            self?.prepareLectureBootstrapAfterWebContentTermination()
+        }
         uiHolder.load(KlasUrls.shared.LECTURE_HOME)
         klasHolder.load(KlasUrls.shared.KLAS_FRAME)
     }
@@ -135,6 +138,7 @@ final class LectureScreenModel: ObservableObject {
     /// KLAS가 비동기로 `오류가 발생하였습니다.` alert를 띄운다. JS에서 `window.alert`를 덮어쓰면
     /// 그 비동기 alert를 놓치므로, 함수가 생길 때까지만 기다린 뒤 네이티브에서 부트스트랩 오류를 삼킨다.
     /// 강의 홈으로 진입하거나 대기 시간이 끝나면 억제를 해제한다. `didOpenLecture`로 주입은 1회다.
+    /// 타임아웃은 `openLectureWhenReady`가 이미 `goLctrum`을 호출한 뒤에도 두 번째 호출을 보내지 않는다.
     private func openLectureIfNeeded() {
         guard !didOpenLecture else { return }
         didOpenLecture = true
@@ -154,15 +158,24 @@ final class LectureScreenModel: ObservableObject {
         openLectureWindowTask?.cancel()
         openLectureWindowTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 5_000_000_000)
-            guard let self, !Task.isCancelled, self.isOpeningLecture else { return }
-            self.finishOpeningLecture(success: false)
-            self.klasHolder.evaluate(
-                KlasWebAutomationScripts.shared.openLecture(
-                    yearSemester: self.yearSemester,
-                    subjectId: self.subjectId
-                )
-            )
+            guard let self, !Task.isCancelled else { return }
+            self.handleOpenLectureWindowExpired()
         }
+    }
+
+    func handleOpenLectureWindowExpired() {
+        guard isOpeningLecture else { return }
+        finishOpeningLecture(success: false)
+    }
+
+    func prepareLectureBootstrapAfterWebContentTermination() {
+        guard isOpeningLecture else { return }
+        didOpenLecture = false
+        isOpeningLecture = false
+        openLectureRetryTask?.cancel()
+        openLectureWindowTask?.cancel()
+        klasHolder.suppressJavaScriptAlertContaining = nil
+        klasHolder.onSuppressedJavaScriptAlert = nil
     }
 
     private func scheduleOpenLectureRetry() {
@@ -358,7 +371,7 @@ struct LectureView: View {
                 }
             }
         }
-        .webJavaScriptAlert(model.uiHolder, model.klasHolder)
+        .webJavaScriptAlert(model.uiHolder, model.klasHolder, secondaryEnabled: model.showingKlas)
         .webDownloadOverlay(model.uiHolder)
         .webDownloadOverlay(model.klasHolder)
         .onReceive(model.klasHolder.$navigationState) { state in

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -1,6 +1,12 @@
 import Shared
 import SwiftUI
 
+enum LectureBootstrap: Equatable {
+    case idle
+    case opening
+    case finished
+}
+
 @MainActor
 final class LectureScreenModel: ObservableObject {
     let uiHolder: WebViewHolder
@@ -17,8 +23,7 @@ final class LectureScreenModel: ObservableObject {
     private var host: LectureHostAdapter
     private var boardNoticePath = ""
     private var boardPdsPath = ""
-    private(set) var didOpenLecture = false
-    private(set) var isOpeningLecture = false
+    private(set) var bootstrap = LectureBootstrap.idle
     private var boardPathCollectTask: Task<Void, Never>?
     private var openLectureRetryTask: Task<Void, Never>?
     private var openLectureWindowTask: Task<Void, Never>?
@@ -137,12 +142,11 @@ final class LectureScreenModel: ObservableObject {
     /// WKWebView `didFinish`는 `goLctrum` 내부 상태가 덜 준비된 시점에 올 수 있고, 그때 호출하면
     /// KLAS가 비동기로 `오류가 발생하였습니다.` alert를 띄운다. JS에서 `window.alert`를 덮어쓰면
     /// 그 비동기 alert를 놓치므로, 함수가 생길 때까지만 기다린 뒤 네이티브에서 부트스트랩 오류를 삼킨다.
-    /// 강의 홈으로 진입하거나 대기 시간이 끝나면 억제를 해제한다. `didOpenLecture`로 주입은 1회다.
+    /// 강의 홈으로 진입하거나 대기 시간이 끝나면 억제를 해제한다. `bootstrap == .finished`면 주입은 1회다.
     /// 타임아웃은 `openLectureWhenReady`가 이미 `goLctrum`을 호출한 뒤에도 두 번째 호출을 보내지 않는다.
     private func openLectureIfNeeded() {
-        guard !didOpenLecture else { return }
-        didOpenLecture = true
-        isOpeningLecture = true
+        guard bootstrap == .idle else { return }
+        bootstrap = .opening
         klasHolder.suppressJavaScriptAlertContaining = Self.bootstrapLectureErrorMarker
         klasHolder.onSuppressedJavaScriptAlert = { [weak self] in
             Task { @MainActor in self?.scheduleOpenLectureRetry() }
@@ -164,25 +168,20 @@ final class LectureScreenModel: ObservableObject {
     }
 
     func handleOpenLectureWindowExpired() {
-        guard isOpeningLecture else { return }
+        guard bootstrap == .opening else { return }
         finishOpeningLecture(success: false)
     }
 
     func prepareLectureBootstrapAfterWebContentTermination() {
-        guard isOpeningLecture else { return }
-        didOpenLecture = false
-        isOpeningLecture = false
-        openLectureRetryTask?.cancel()
-        openLectureWindowTask?.cancel()
-        klasHolder.suppressJavaScriptAlertContaining = nil
-        klasHolder.onSuppressedJavaScriptAlert = nil
+        guard bootstrap == .opening else { return }
+        clearOpeningWork(next: .idle)
     }
 
     private func scheduleOpenLectureRetry() {
         openLectureRetryTask?.cancel()
         openLectureRetryTask = Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 250_000_000)
-            guard let self, !Task.isCancelled, self.isOpeningLecture else { return }
+            guard let self, !Task.isCancelled, self.bootstrap == .opening else { return }
             self.klasHolder.evaluate(
                 KlasWebAutomationScripts.shared.openLecture(
                     yearSemester: self.yearSemester,
@@ -193,14 +192,18 @@ final class LectureScreenModel: ObservableObject {
     }
 
     private func finishOpeningLecture(success: Bool) {
-        isOpeningLecture = false
+        clearOpeningWork(next: bootstrap == .opening ? .finished : bootstrap)
+        if success, let message = klasHolder.javaScriptAlertMessage, Self.isBootstrapLectureError(message) {
+            klasHolder.confirmJavaScriptAlert()
+        }
+    }
+
+    private func clearOpeningWork(next: LectureBootstrap) {
         openLectureRetryTask?.cancel()
         openLectureWindowTask?.cancel()
         klasHolder.suppressJavaScriptAlertContaining = nil
         klasHolder.onSuppressedJavaScriptAlert = nil
-        if success, let message = klasHolder.javaScriptAlertMessage, Self.isBootstrapLectureError(message) {
-            klasHolder.confirmJavaScriptAlert()
-        }
+        bootstrap = next
     }
 
     nonisolated static let bootstrapLectureErrorMarker = "오류가 발생"
@@ -320,26 +323,12 @@ struct LectureView: View {
         ZStack {
             WebViewContainer(webView: model.uiHolder.webView)
                 .webSurfaceLayout()
-                .accessibilityHidden(
-                    model.isLoading
-                        || model.showingKlas
-                        || model.uiHolder.javaScriptAlertMessage != nil
-                        || model.klasHolder.javaScriptAlertMessage != nil
-                        || model.uiHolder.downloadProgress != nil
-                        || model.klasHolder.downloadProgress != nil
-                )
+                .accessibilityHidden(hidesWebForOverlay || model.showingKlas)
             WebViewContainer(webView: model.klasHolder.webView)
                 .webSurfaceLayout()
                 .opacity(model.showingKlas ? 1 : 0)
                 .allowsHitTesting(model.showingKlas)
-                .accessibilityHidden(
-                    model.isLoading
-                        || !model.showingKlas
-                        || model.uiHolder.javaScriptAlertMessage != nil
-                        || model.klasHolder.javaScriptAlertMessage != nil
-                        || model.uiHolder.downloadProgress != nil
-                        || model.klasHolder.downloadProgress != nil
-                )
+                .accessibilityHidden(hidesWebForOverlay || !model.showingKlas)
             if model.isLoading {
                 KlasLoadingView(message: "불러오는 중")
             }
@@ -378,5 +367,13 @@ struct LectureView: View {
             model.handleKlasNavigation(state)
         }
         .accessibilityIdentifier("lecture_view")
+    }
+
+    private var hidesWebForOverlay: Bool {
+        model.isLoading
+            || model.uiHolder.javaScriptAlertMessage != nil
+            || model.klasHolder.javaScriptAlertMessage != nil
+            || model.uiHolder.downloadProgress != nil
+            || model.klasHolder.downloadProgress != nil
     }
 }

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -359,7 +359,8 @@ struct LectureView: View {
             }
         }
         .webJavaScriptAlert(model.uiHolder, model.klasHolder)
-        .webDownloadOverlay(model.uiHolder, model.klasHolder)
+        .webDownloadOverlay(model.uiHolder)
+        .webDownloadOverlay(model.klasHolder)
         .onReceive(model.klasHolder.$navigationState) { state in
             model.handleKlasNavigation(state)
         }

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -18,7 +18,10 @@ final class LectureScreenModel: ObservableObject {
     private var boardNoticePath = ""
     private var boardPdsPath = ""
     private var didOpenLecture = false
+    private var isOpeningLecture = false
     private var boardPathCollectTask: Task<Void, Never>?
+    private var openLectureRetryTask: Task<Void, Never>?
+    private var openLectureWindowTask: Task<Void, Never>?
 
     init(
         subjectId: String,
@@ -49,6 +52,8 @@ final class LectureScreenModel: ObservableObject {
 
     deinit {
         boardPathCollectTask?.cancel()
+        openLectureRetryTask?.cancel()
+        openLectureWindowTask?.cancel()
         uiHolder.dispose()
         klasHolder.dispose()
     }
@@ -119,20 +124,25 @@ final class LectureScreenModel: ObservableObject {
             if isLoading { isLoading = false }
         }
         if url.contains("LctrumHomeStdPage.do") {
+            finishOpeningLecture(success: true)
             collectBoardPathsUntilReady()
             if showingKlas { showingKlas = false }
         }
     }
 
     /// Android는 `Frame.do` 로드 시 `KlasWebAutomationScripts.openLecture(...)`를 즉시 한 번만 호출한다.
-    /// (Android WebView의 `onPageFinished`는 페이지 스크립트 초기화가 끝난 뒤 불린다.)
-    /// WKWebView `didFinish`는 `appModule.goLctrum`이 함수로만 존재하고 내부 상태가 덜 준비된
-    /// 시점에 올 수 있다. 그때 호출하면 KLAS가 `오류가 발생하였습니다.` alert를 띄운다.
-    /// `openLectureWhenReady`는 함수가 생길 때까지 기다린 뒤 호출하고, 그 부트스트랩 alert가
-    /// 나면 삼키고 재시도한다. `didOpenLecture`로 화면당 주입은 1회로 제한한다.
+    /// WKWebView `didFinish`는 `goLctrum` 내부 상태가 덜 준비된 시점에 올 수 있고, 그때 호출하면
+    /// KLAS가 비동기로 `오류가 발생하였습니다.` alert를 띄운다. JS에서 `window.alert`를 덮어쓰면
+    /// 그 비동기 alert를 놓치므로, 함수가 생길 때까지만 기다린 뒤 네이티브에서 부트스트랩 오류를 삼킨다.
+    /// 강의 홈으로 진입하거나 대기 시간이 끝나면 억제를 해제한다. `didOpenLecture`로 주입은 1회다.
     private func openLectureIfNeeded() {
         guard !didOpenLecture else { return }
         didOpenLecture = true
+        isOpeningLecture = true
+        klasHolder.suppressJavaScriptAlertContaining = Self.bootstrapLectureErrorMarker
+        klasHolder.onSuppressedJavaScriptAlert = { [weak self] in
+            Task { @MainActor in self?.scheduleOpenLectureRetry() }
+        }
         klasHolder.evaluate(
             KlasWebAutomationScripts.shared.openLectureWhenReady(
                 yearSemester: yearSemester,
@@ -141,6 +151,49 @@ final class LectureScreenModel: ObservableObject {
                 intervalMs: 250,
             )
         )
+        openLectureWindowTask?.cancel()
+        openLectureWindowTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard let self, !Task.isCancelled, self.isOpeningLecture else { return }
+            self.finishOpeningLecture(success: false)
+            self.klasHolder.evaluate(
+                KlasWebAutomationScripts.shared.openLecture(
+                    yearSemester: self.yearSemester,
+                    subjectId: self.subjectId
+                )
+            )
+        }
+    }
+
+    private func scheduleOpenLectureRetry() {
+        openLectureRetryTask?.cancel()
+        openLectureRetryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard let self, !Task.isCancelled, self.isOpeningLecture else { return }
+            self.klasHolder.evaluate(
+                KlasWebAutomationScripts.shared.openLecture(
+                    yearSemester: self.yearSemester,
+                    subjectId: self.subjectId
+                )
+            )
+        }
+    }
+
+    private func finishOpeningLecture(success: Bool) {
+        isOpeningLecture = false
+        openLectureRetryTask?.cancel()
+        openLectureWindowTask?.cancel()
+        klasHolder.suppressJavaScriptAlertContaining = nil
+        klasHolder.onSuppressedJavaScriptAlert = nil
+        if success, let message = klasHolder.javaScriptAlertMessage, Self.isBootstrapLectureError(message) {
+            klasHolder.confirmJavaScriptAlert()
+        }
+    }
+
+    nonisolated static let bootstrapLectureErrorMarker = "오류가 발생"
+
+    nonisolated static func isBootstrapLectureError(_ message: String) -> Bool {
+        message.contains(bootstrapLectureErrorMarker)
     }
 
     /// Android는 `LctrumHomeStdPage.do` 로드 시 `collectLectureBoardPaths()`를 한 번만 실행한다.
@@ -305,11 +358,7 @@ struct LectureView: View {
                 }
             }
         }
-        .webJavaScriptAlert(
-            model.uiHolder,
-            model.klasHolder,
-            activeSecondary: model.showingKlas
-        )
+        .webJavaScriptAlert(model.uiHolder, model.klasHolder)
         .webDownloadOverlay(model.uiHolder, model.klasHolder)
         .onReceive(model.klasHolder.$navigationState) { state in
             model.handleKlasNavigation(state)

--- a/iosApp/iosApp/LinkView.swift
+++ b/iosApp/iosApp/LinkView.swift
@@ -79,7 +79,7 @@ struct LinkView: View {
     }
 
     var body: some View {
-        PushedWebStack(holder: model.holder, isLoading: model.holder.isLoading) {
+        PushedWebStack(holder: model.holder) {
             model.handleBack(dismiss: { dismiss() })
         }
         .accessibilityIdentifier("link_view")

--- a/iosApp/iosApp/LinkWebViewScreen.swift
+++ b/iosApp/iosApp/LinkWebViewScreen.swift
@@ -14,6 +14,7 @@ struct LinkWebViewScreen: View {
         LinkWebView(url: url, onClose: onDismiss)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.white.ignoresSafeArea())
+            .webSurfaceLayout(.embedded)
             .accessibilityIdentifier("link_web_view")
     }
 }
@@ -31,6 +32,13 @@ private struct LinkWebView: UIViewRepresentable {
         configuration.websiteDataStore = .default()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
         configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: WebSurfaceViewportScript.source,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+        )
 
         let closeName = Coordinator.closeHandlerName
         configuration.userContentController.add(context.coordinator, name: closeName)

--- a/iosApp/iosApp/LoginView.swift
+++ b/iosApp/iosApp/LoginView.swift
@@ -155,9 +155,9 @@ private struct LoginFormContent: View {
             let widthClass = AppWindowWidthClass.classify(width: proxy.size.width)
             switch widthClass {
             case .expanded:
-                HStack(spacing: 64) {
+                HStack(alignment: .top, spacing: 64) {
                     LoginHeader(passwordVisible: state.passwordFieldVisible)
-                        .frame(maxWidth: .infinity)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     LoginFields(
                         state: $state,
                         focusedField: $focusedField,
@@ -165,11 +165,12 @@ private struct LoginFormContent: View {
                         onOpenURL: onOpenURL,
                         showSubmitActions: true
                     )
-                    .frame(maxWidth: 520)
-                    .frame(maxWidth: .infinity)
+                    .frame(maxWidth: 520, alignment: .top)
+                    .frame(maxWidth: .infinity, alignment: .top)
                 }
                 .padding(.horizontal, 64)
                 .padding(.vertical, 32)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             case .compact:
                 ZStack(alignment: .bottom) {
                     ScrollView {
@@ -260,6 +261,7 @@ private struct KlasOutlinedTextField<Trailing: View>: View {
     var isSecure: Bool
     var accessibilityId: String
     @ViewBuilder var trailing: () -> Trailing
+    @ScaledMetric(relativeTo: .body) private var fieldHeight: CGFloat = 56
 
     init(
         label: String,
@@ -327,10 +329,11 @@ private struct KlasOutlinedTextField<Trailing: View>: View {
                             .padding(.horizontal, -2)
                     }
                 }
-                .offset(x: isFloating ? 12 : 16, y: isFloating ? -28 : 0)
+                .offset(x: isFloating ? 12 : 16, y: isFloating ? -fieldHeight / 2 : 0)
                 .allowsHitTesting(false)
         }
-        .frame(height: 56)
+        .frame(height: fieldHeight)
+        .fixedSize(horizontal: false, vertical: true)
         .padding(.top, 8)
         .animation(.easeOut(duration: 0.15), value: isFloating)
         .animation(.easeOut(duration: 0.15), value: isFocused)

--- a/iosApp/iosApp/M6011FixtureView.swift
+++ b/iosApp/iosApp/M6011FixtureView.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+enum M6011UITestConfiguration {
+    static let launchArgument = "-m6011-ui-test"
+
+    static var isEnabled: Bool {
+        ProcessInfo.processInfo.arguments.contains(launchArgument)
+    }
+
+    static var dynamicTypeSize: DynamicTypeSize {
+        switch ProcessInfo.processInfo.environment["M6011_DYNAMIC_TYPE"] {
+        case "accessibility5":
+            return .accessibility5
+        case "accessibility3":
+            return .accessibility3
+        default:
+            return .large
+        }
+    }
+}
+
+@MainActor
+final class M6011FixtureModel: ObservableObject {
+    let holder: WebViewHolder
+    @Published var showSelection = false
+    @Published var showDownload = false
+    @Published var showAlert = false
+
+    init() {
+        holder = WebViewHolder()
+        holder.loadHTML(Self.html, baseURL: Self.baseURL)
+    }
+
+    deinit {
+        holder.dispose()
+    }
+
+    private static let baseURL = URL(string: "https://klasplus.yuntae.in/m6011-fixture")!
+
+    private static let html = """
+    <!doctype html>
+    <html>
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <style>
+          :root { color-scheme: light dark; }
+          * { box-sizing: border-box; }
+          html, body { margin: 0; min-height: 100%; font: -apple-system-body; }
+          body { padding: 24px 16px 120px; }
+          main { min-height: 140vh; }
+          h1 { font: -apple-system-title3; }
+          input, button { font: -apple-system-body; min-height: 48px; padding: 8px 12px; }
+          input { width: 100%; margin: 16px 0; }
+          .fixed-nav {
+            position: fixed; left: 0; right: 0; bottom: 0;
+            min-height: 56px; padding: 8px 16px;
+            padding-bottom: max(8px, env(safe-area-inset-bottom));
+            background: Canvas; border-top: 1px solid GrayText;
+          }
+        </style>
+      </head>
+      <body>
+        <main>
+          <h1>Web content fixture</h1>
+          <p>화면 회전과 키보드 표시 중에도 본문과 하단 내비게이션이 유지됩니다.</p>
+          <label for="m6011-input">웹 입력</label>
+          <input id="m6011-input" aria-label="웹 입력" type="text" placeholder="입력 후 키보드를 확인하세요">
+          <p>스크롤 가능한 Web content</p>
+        </main>
+        <nav class="fixed-nav" aria-label="웹 하단 내비게이션">웹 하단 내비게이션</nav>
+      </body>
+    </html>
+    """
+}
+
+struct M6011FixtureRootView: View {
+    @StateObject private var model = M6011FixtureModel()
+    @AccessibilityFocusState private var focusedControl: FixtureFocus?
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .bottom) {
+                WebViewContainer(
+                    webView: model.holder.webView,
+                    accessibilityIdentifier: "m6011_web_surface"
+                )
+                .webSurfaceLayout()
+                .accessibilityHidden(
+                    model.showSelection || model.showAlert || model.showDownload
+                )
+                controls
+                    .padding(.bottom, 8)
+                    .zIndex(1)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .sheet(isPresented: $model.showSelection) {
+                    SelectionBottomSheet(
+                        title: "환경 확인",
+                        description: "Dynamic Type에서도 모든 항목을 읽을 수 있어야 합니다.",
+                        options: [
+                            SelectionOptionRow(title: "첫 번째 항목") {
+                                model.showSelection = false
+                            },
+                            SelectionOptionRow(title: "두 번째 항목") {
+                                model.showSelection = false
+                            },
+                        ]
+                    )
+                }
+                .onChange(of: model.showSelection) { isPresented in
+                    if !isPresented {
+                        DispatchQueue.main.async {
+                            focusedControl = .sheetButton
+                        }
+                    }
+                }
+                .alert("환경 확인", isPresented: $model.showAlert) {
+                    Button("확인", role: .cancel) {}
+                } message: {
+                    Text("Native overlay가 Web content 위에 한 번만 표시됩니다.")
+                }
+                .overlay {
+                    if model.showDownload {
+                        DownloadProgressOverlay(
+                            fileName: "fixture.pdf",
+                            fraction: 0.5,
+                            onCancel: { model.showDownload = false }
+                        )
+                    }
+                }
+                .navigationTitle("M6-011 Fixture")
+                .navigationBarTitleDisplayMode(.inline)
+        }
+        .accessibilityIdentifier("m6011_fixture_root")
+    }
+
+    private var controls: some View {
+        HStack(spacing: 8) {
+            Button("시트") { model.showSelection = true }
+                .accessibilityIdentifier("m6011_sheet_button")
+                .accessibilityFocused($focusedControl, equals: .sheetButton)
+            Button("알림") { model.showAlert = true }
+                .accessibilityIdentifier("m6011_alert_button")
+            Button("다운로드") { model.showDownload = true }
+                .accessibilityIdentifier("m6011_download_button")
+        }
+        .buttonStyle(.bordered)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(KlasTheme.surface)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("m6011_native_controls")
+    }
+}
+
+private enum FixtureFocus: Hashable {
+    case sheetButton
+}

--- a/iosApp/iosApp/PushedWebStack.swift
+++ b/iosApp/iosApp/PushedWebStack.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct PushedWebStack: View {
     @ObservedObject var holder: WebViewHolder
-    var isLoading: Bool
     var onBack: () -> Void
 
     var body: some View {
@@ -10,12 +9,18 @@ struct PushedWebStack: View {
             WebViewContainer(webView: holder.webView)
                 .webSurfaceLayout()
                 .accessibilityHidden(
-                    isLoading
+                    holder.isLoading
+                        || holder.isFailed
                         || holder.javaScriptAlertMessage != nil
                         || holder.downloadProgress != nil
                 )
-            if isLoading {
+            if holder.isLoading {
                 KlasLoadingView(message: "불러오는 중")
+            } else if case let .failed(_, category) = holder.navigationState.loadPhase {
+                HomeFailureView(
+                    message: HomeCoordinator.pageLoadFailureMessage(for: category),
+                    onRetry: { holder.reload() }
+                )
             }
         }
         .navigationBarBackButtonHidden(true)
@@ -43,6 +48,11 @@ struct PushedWebStack: View {
 extension WebViewHolder {
     var isLoading: Bool {
         if case .loading = navigationState.loadPhase { return true }
+        return false
+    }
+
+    var isFailed: Bool {
+        if case .failed = navigationState.loadPhase { return true }
         return false
     }
 }

--- a/iosApp/iosApp/PushedWebStack.swift
+++ b/iosApp/iosApp/PushedWebStack.swift
@@ -8,7 +8,12 @@ struct PushedWebStack: View {
     var body: some View {
         ZStack {
             WebViewContainer(webView: holder.webView)
-                .ignoresSafeArea(edges: .bottom)
+                .webSurfaceLayout()
+                .accessibilityHidden(
+                    isLoading
+                        || holder.javaScriptAlertMessage != nil
+                        || holder.downloadProgress != nil
+                )
             if isLoading {
                 KlasLoadingView(message: "불러오는 중")
             }

--- a/iosApp/iosApp/PushedWebStack.swift
+++ b/iosApp/iosApp/PushedWebStack.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct PushedWebStack: View {
     @ObservedObject var holder: WebViewHolder
+    var showsPageLoading: Bool = true
     var onBack: () -> Void
 
     var body: some View {
@@ -9,12 +10,12 @@ struct PushedWebStack: View {
             WebViewContainer(webView: holder.webView)
                 .webSurfaceLayout()
                 .accessibilityHidden(
-                    holder.isLoading
+                    showsPageLoadingOverlay
                         || holder.isFailed
                         || holder.javaScriptAlertMessage != nil
                         || holder.downloadProgress != nil
                 )
-            if holder.isLoading {
+            if showsPageLoadingOverlay {
                 KlasLoadingView(message: "불러오는 중")
             } else if case let .failed(_, category) = holder.navigationState.loadPhase {
                 HomeFailureView(
@@ -42,6 +43,10 @@ struct PushedWebStack: View {
         }
         .webJavaScriptAlert(holder)
         .webDownloadOverlay(holder)
+    }
+
+    private var showsPageLoadingOverlay: Bool {
+        showsPageLoading && holder.isLoading && holder.downloadProgress == nil
     }
 }
 

--- a/iosApp/iosApp/SelectionBottomSheet.swift
+++ b/iosApp/iosApp/SelectionBottomSheet.swift
@@ -13,6 +13,7 @@ struct SelectionBottomSheet: View {
     var description: String? = nil
     var options: [SelectionOptionRow]
 
+    @AccessibilityFocusState private var focusedElement: SelectionFocus?
     @State private var contentHeight: CGFloat = 240
 
     var body: some View {
@@ -20,7 +21,10 @@ struct SelectionBottomSheet: View {
             sheetBody
                 .background {
                     GeometryReader { proxy in
-                        Color.clear.preference(key: SheetContentHeightKey.self, value: proxy.size.height)
+                        Color.clear.preference(
+                            key: SheetContentHeightKey.self,
+                            value: proxy.size.height
+                        )
                     }
                 }
         }
@@ -29,22 +33,30 @@ struct SelectionBottomSheet: View {
         .presentationDetents([.height(detentHeight)])
         .presentationDragIndicator(.visible)
         .modifier(SelectionSheetSurfaceBackground())
-        .onPreferenceChange(SheetContentHeightKey.self) { contentHeight = $0 }
         .tint(KlasTheme.primary)
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("selection_bottom_sheet")
+        .onPreferenceChange(SheetContentHeightKey.self) { contentHeight = $0 }
+        .onAppear {
+            DispatchQueue.main.async {
+                focusedElement = title == nil ? .firstOption : .heading
+            }
+        }
     }
 
     private var sheetBody: some View {
         VStack(alignment: .leading, spacing: 0) {
             if let title {
                 Text(title)
-                    .font(.system(size: 22, weight: .bold))
+                    .font(.title2.weight(.bold))
                     .foregroundStyle(KlasTheme.onSurfaceVariant)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .accessibilityAddTraits(.isHeader)
+                    .accessibilityFocused($focusedElement, equals: .heading)
             }
             if let description {
                 Text(description)
-                    .font(.system(size: 14))
+                    .font(.subheadline)
                     .foregroundStyle(KlasTheme.onSurfaceVariant)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.top, title == nil ? 0 : 4)
@@ -59,13 +71,16 @@ struct SelectionBottomSheet: View {
                 .buttonStyle(KlasSelectionRowButtonStyle())
                 .accessibilityAddTraits(option.isSelected ? .isSelected : [])
                 .accessibilityIdentifier("selection_option_\(index)")
+                .accessibilityFocused(
+                    $focusedElement,
+                    equals: index == 0 ? .firstOption : nil
+                )
             }
         }
         .padding(20)
         .padding(.top, (title != nil || description != nil) ? 20 : 0)
         .frame(maxWidth: 640)
         .frame(maxWidth: .infinity)
-        .accessibilityIdentifier("selection_bottom_sheet")
     }
 
     private var grabberAllowance: CGFloat { 20 }
@@ -77,6 +92,12 @@ struct SelectionBottomSheet: View {
     private var detentHeight: CGFloat {
         min(max(contentHeight + grabberAllowance, 1), maxDetent)
     }
+
+}
+
+private enum SelectionFocus: Hashable {
+    case heading
+    case firstOption
 }
 
 private struct SelectionSheetSurfaceBackground: ViewModifier {

--- a/iosApp/iosApp/SelectionBottomSheet.swift
+++ b/iosApp/iosApp/SelectionBottomSheet.swift
@@ -65,22 +65,29 @@ struct SelectionBottomSheet: View {
                 Color.clear.frame(height: 16)
             }
             ForEach(Array(options.enumerated()), id: \.offset) { index, option in
-                Button(action: option.action) {
-                    Text(option.title)
-                }
-                .buttonStyle(KlasSelectionRowButtonStyle())
-                .accessibilityAddTraits(option.isSelected ? .isSelected : [])
-                .accessibilityIdentifier("selection_option_\(index)")
-                .accessibilityFocused(
-                    $focusedElement,
-                    equals: index == 0 ? .firstOption : nil
-                )
+                optionButton(index: index, option: option)
             }
         }
         .padding(20)
         .padding(.top, (title != nil || description != nil) ? 20 : 0)
         .frame(maxWidth: 640)
         .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private func optionButton(index: Int, option: SelectionOptionRow) -> some View {
+        let button = Button(action: option.action) {
+            Text(option.title)
+        }
+        .buttonStyle(KlasSelectionRowButtonStyle())
+        .accessibilityAddTraits(option.isSelected ? .isSelected : [])
+        .accessibilityIdentifier("selection_option_\(index)")
+
+        if index == 0 {
+            button.accessibilityFocused($focusedElement, equals: .firstOption)
+        } else {
+            button
+        }
     }
 
     private var grabberAllowance: CGFloat { 20 }

--- a/iosApp/iosApp/SettingsView.swift
+++ b/iosApp/iosApp/SettingsView.swift
@@ -85,7 +85,7 @@ struct SettingsView: View {
     }
 
     var body: some View {
-        PushedWebStack(holder: model.holder, isLoading: model.holder.isLoading) {
+        PushedWebStack(holder: model.holder) {
             if model.holder.goBack() { return }
             dismiss()
         }

--- a/iosApp/iosApp/TaskView.swift
+++ b/iosApp/iosApp/TaskView.swift
@@ -68,7 +68,7 @@ struct TaskView: View {
     }
 
     var body: some View {
-        PushedWebStack(holder: model.holder, isLoading: model.holder.isLoading) {
+        PushedWebStack(holder: model.holder) {
             if model.holder.goBack() { return }
             dismiss()
         }

--- a/iosApp/iosApp/WebSurfaceOverlays.swift
+++ b/iosApp/iosApp/WebSurfaceOverlays.swift
@@ -1,18 +1,6 @@
 import SwiftUI
 
 extension View {
-    func webDownloadOverlay(_ holder: WebViewHolder) -> some View {
-        overlay {
-            WebSurfaceOverlayHost(primary: holder)
-        }
-    }
-
-    func webDownloadOverlay(_ primary: WebViewHolder, _ secondary: WebViewHolder) -> some View {
-        overlay {
-            WebSurfaceOverlayHost(primary: primary, secondary: secondary)
-        }
-    }
-
     func webJavaScriptAlert(_ holder: WebViewHolder, enabled: Bool = true) -> some View {
         alert(
             "안내",
@@ -39,62 +27,6 @@ extension View {
         overlay {
             WebJavaScriptAlertHost(primary: primary, secondary: secondary)
         }
-    }
-}
-
-struct WebSurfaceOverlayHost: View {
-    @ObservedObject var primary: WebViewHolder
-    @ObservedObject var secondary: WebViewHolder
-    private let isDual: Bool
-
-    init(primary: WebViewHolder, secondary: WebViewHolder? = nil) {
-        self.primary = primary
-        self.secondary = secondary ?? primary
-        self.isDual = secondary != nil
-    }
-
-    var body: some View {
-        ZStack {
-            if let holder = progressHolder, let progress = holder.downloadProgress {
-                DownloadProgressOverlay(
-                    fileName: progress.fileName,
-                    fraction: progress.fraction,
-                    onCancel: { holder.cancelDownload() }
-                )
-            }
-        }
-        .alert(
-            "다운로드 실패",
-            isPresented: Binding(
-                get: { downloadErrorMessage != nil },
-                set: { if !$0 { dismissDownloadError() } }
-            )
-        ) {
-            Button("확인") { dismissDownloadError() }
-        } message: {
-            Text(downloadErrorMessage ?? "")
-        }
-        .accessibilityIdentifier("web_surface_overlay_host")
-    }
-
-    private var holders: [WebViewHolder] {
-        isDual ? [primary, secondary] : [primary]
-    }
-
-    private var progressHolder: WebViewHolder? {
-        holders.first { $0.downloadProgress != nil }
-    }
-
-    private var errorHolder: WebViewHolder? {
-        holders.first { $0.downloadErrorMessage != nil }
-    }
-
-    private var downloadErrorMessage: String? {
-        errorHolder?.downloadErrorMessage
-    }
-
-    private func dismissDownloadError() {
-        errorHolder?.clearDownloadError()
     }
 }
 

--- a/iosApp/iosApp/WebSurfaceOverlays.swift
+++ b/iosApp/iosApp/WebSurfaceOverlays.swift
@@ -22,36 +22,93 @@ extension View {
 
     func webJavaScriptAlert(
         _ primary: WebViewHolder,
-        _ secondary: WebViewHolder
+        _ secondary: WebViewHolder,
+        secondaryEnabled: Bool = true
     ) -> some View {
         overlay {
-            WebJavaScriptAlertHost(primary: primary, secondary: secondary)
+            WebJavaScriptAlertHost(
+                primary: primary,
+                secondary: secondary,
+                secondaryEnabled: secondaryEnabled
+            )
         }
+    }
+}
+
+enum WebJavaScriptAlertPresentation {
+    static func holder(
+        primary: WebViewHolder,
+        secondary: WebViewHolder,
+        secondaryEnabled: Bool,
+        sticky: WebViewHolder?
+    ) -> WebViewHolder? {
+        if let sticky, sticky.javaScriptAlertMessage != nil {
+            return sticky
+        }
+        if primary.javaScriptAlertMessage != nil {
+            return primary
+        }
+        if secondaryEnabled, secondary.javaScriptAlertMessage != nil {
+            return secondary
+        }
+        return nil
     }
 }
 
 struct WebJavaScriptAlertHost: View {
     @ObservedObject var primary: WebViewHolder
     @ObservedObject var secondary: WebViewHolder
+    var secondaryEnabled: Bool = true
+    @State private var presentedHolder: WebViewHolder?
 
     var body: some View {
         EmptyView()
             .alert(
                 "안내",
                 isPresented: Binding(
-                    get: { presentingHolder != nil },
-                    set: { if !$0 { presentingHolder?.confirmJavaScriptAlert() } }
+                    get: { presentedHolder?.javaScriptAlertMessage != nil },
+                    set: { if !$0 { presentedHolder?.confirmJavaScriptAlert() } }
                 )
             ) {
-                Button("확인") { presentingHolder?.confirmJavaScriptAlert() }
+                Button("확인") { presentedHolder?.confirmJavaScriptAlert() }
             } message: {
-                Text(presentingHolder?.javaScriptAlertMessage ?? "")
+                Text(presentedHolder?.javaScriptAlertMessage ?? "")
+            }
+            .onReceive(primary.$javaScriptAlertMessage) { _ in
+                refreshPresentedHolder()
+            }
+            .onReceive(secondary.$javaScriptAlertMessage) { message in
+                if !secondaryEnabled, message != nil {
+                    secondary.confirmJavaScriptAlert()
+                    return
+                }
+                refreshPresentedHolder()
+            }
+            .onChange(of: secondaryEnabled) { enabled in
+                if !enabled, secondary.javaScriptAlertMessage != nil {
+                    secondary.confirmJavaScriptAlert()
+                }
+                refreshPresentedHolder()
             }
     }
 
-    private var presentingHolder: WebViewHolder? {
-        if primary.javaScriptAlertMessage != nil { return primary }
-        if secondary.javaScriptAlertMessage != nil { return secondary }
-        return nil
+    private func refreshPresentedHolder() {
+        let next = WebJavaScriptAlertPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: secondaryEnabled,
+            sticky: presentedHolder
+        )
+        if presentedHolder === next {
+            return
+        }
+        if presentedHolder != nil, next != nil {
+            presentedHolder = nil
+            DispatchQueue.main.async {
+                refreshPresentedHolder()
+            }
+            return
+        }
+        presentedHolder = next
     }
 }

--- a/iosApp/iosApp/WebSurfaceOverlays.swift
+++ b/iosApp/iosApp/WebSurfaceOverlays.swift
@@ -1,0 +1,139 @@
+import SwiftUI
+
+extension View {
+    func webDownloadOverlay(_ holder: WebViewHolder) -> some View {
+        overlay {
+            WebSurfaceOverlayHost(primary: holder)
+        }
+    }
+
+    func webDownloadOverlay(_ primary: WebViewHolder, _ secondary: WebViewHolder) -> some View {
+        overlay {
+            WebSurfaceOverlayHost(primary: primary, secondary: secondary)
+        }
+    }
+
+    func webJavaScriptAlert(_ holder: WebViewHolder, enabled: Bool = true) -> some View {
+        alert(
+            "안내",
+            isPresented: Binding(
+                get: { enabled && holder.javaScriptAlertMessage != nil },
+                set: { if !$0 { holder.confirmJavaScriptAlert() } }
+            )
+        ) {
+            Button("확인") { holder.confirmJavaScriptAlert() }
+        } message: {
+            Text(holder.javaScriptAlertMessage ?? "")
+        }
+        .onReceive(holder.$javaScriptAlertMessage) { message in
+            if !enabled, message != nil {
+                holder.confirmJavaScriptAlert()
+            }
+        }
+    }
+
+    func webJavaScriptAlert(
+        _ primary: WebViewHolder,
+        _ secondary: WebViewHolder,
+        activeSecondary: Bool
+    ) -> some View {
+        overlay {
+            WebJavaScriptAlertHost(
+                primary: primary,
+                secondary: secondary,
+                activeSecondary: activeSecondary
+            )
+        }
+    }
+}
+
+struct WebSurfaceOverlayHost: View {
+    @ObservedObject var primary: WebViewHolder
+    @ObservedObject var secondary: WebViewHolder
+    private let isDual: Bool
+
+    init(primary: WebViewHolder, secondary: WebViewHolder? = nil) {
+        self.primary = primary
+        self.secondary = secondary ?? primary
+        self.isDual = secondary != nil
+    }
+
+    var body: some View {
+        ZStack {
+            if let holder = progressHolder, let progress = holder.downloadProgress {
+                DownloadProgressOverlay(
+                    fileName: progress.fileName,
+                    fraction: progress.fraction,
+                    onCancel: { holder.cancelDownload() }
+                )
+            }
+        }
+        .alert(
+            "다운로드 실패",
+            isPresented: Binding(
+                get: { downloadErrorMessage != nil },
+                set: { if !$0 { dismissDownloadError() } }
+            )
+        ) {
+            Button("확인") { dismissDownloadError() }
+        } message: {
+            Text(downloadErrorMessage ?? "")
+        }
+        .accessibilityIdentifier("web_surface_overlay_host")
+    }
+
+    private var holders: [WebViewHolder] {
+        isDual ? [primary, secondary] : [primary]
+    }
+
+    private var progressHolder: WebViewHolder? {
+        holders.first { $0.downloadProgress != nil }
+    }
+
+    private var errorHolder: WebViewHolder? {
+        holders.first { $0.downloadErrorMessage != nil }
+    }
+
+    private var downloadErrorMessage: String? {
+        errorHolder?.downloadErrorMessage
+    }
+
+    private func dismissDownloadError() {
+        errorHolder?.clearDownloadError()
+    }
+}
+
+struct WebJavaScriptAlertHost: View {
+    @ObservedObject var primary: WebViewHolder
+    @ObservedObject var secondary: WebViewHolder
+    let activeSecondary: Bool
+
+    var body: some View {
+        EmptyView()
+            .alert(
+                "안내",
+                isPresented: Binding(
+                    get: { activeHolder.javaScriptAlertMessage != nil },
+                    set: { if !$0 { activeHolder.confirmJavaScriptAlert() } }
+                )
+            ) {
+                Button("확인") { activeHolder.confirmJavaScriptAlert() }
+            } message: {
+                Text(activeHolder.javaScriptAlertMessage ?? "")
+            }
+            .onReceive(primary.$javaScriptAlertMessage) { message in
+                if activeSecondary, message != nil {
+                    primary.confirmJavaScriptAlert()
+                }
+            }
+            .onReceive(secondary.$javaScriptAlertMessage) { message in
+                if !activeSecondary, message != nil {
+                    secondary.confirmJavaScriptAlert()
+                }
+            }
+    }
+
+    private var activeHolder: WebViewHolder {
+        activeSecondary ? secondary : primary
+    }
+}

--- a/iosApp/iosApp/WebSurfaceOverlays.swift
+++ b/iosApp/iosApp/WebSurfaceOverlays.swift
@@ -34,15 +34,10 @@ extension View {
 
     func webJavaScriptAlert(
         _ primary: WebViewHolder,
-        _ secondary: WebViewHolder,
-        activeSecondary: Bool
+        _ secondary: WebViewHolder
     ) -> some View {
         overlay {
-            WebJavaScriptAlertHost(
-                primary: primary,
-                secondary: secondary,
-                activeSecondary: activeSecondary
-            )
+            WebJavaScriptAlertHost(primary: primary, secondary: secondary)
         }
     }
 }
@@ -106,34 +101,25 @@ struct WebSurfaceOverlayHost: View {
 struct WebJavaScriptAlertHost: View {
     @ObservedObject var primary: WebViewHolder
     @ObservedObject var secondary: WebViewHolder
-    let activeSecondary: Bool
 
     var body: some View {
         EmptyView()
             .alert(
                 "안내",
                 isPresented: Binding(
-                    get: { activeHolder.javaScriptAlertMessage != nil },
-                    set: { if !$0 { activeHolder.confirmJavaScriptAlert() } }
+                    get: { presentingHolder != nil },
+                    set: { if !$0 { presentingHolder?.confirmJavaScriptAlert() } }
                 )
             ) {
-                Button("확인") { activeHolder.confirmJavaScriptAlert() }
+                Button("확인") { presentingHolder?.confirmJavaScriptAlert() }
             } message: {
-                Text(activeHolder.javaScriptAlertMessage ?? "")
-            }
-            .onReceive(primary.$javaScriptAlertMessage) { message in
-                if activeSecondary, message != nil {
-                    primary.confirmJavaScriptAlert()
-                }
-            }
-            .onReceive(secondary.$javaScriptAlertMessage) { message in
-                if !activeSecondary, message != nil {
-                    secondary.confirmJavaScriptAlert()
-                }
+                Text(presentingHolder?.javaScriptAlertMessage ?? "")
             }
     }
 
-    private var activeHolder: WebViewHolder {
-        activeSecondary ? secondary : primary
+    private var presentingHolder: WebViewHolder? {
+        if primary.javaScriptAlertMessage != nil { return primary }
+        if secondary.javaScriptAlertMessage != nil { return secondary }
+        return nil
     }
 }

--- a/iosApp/iosApp/WebViewContainer.swift
+++ b/iosApp/iosApp/WebViewContainer.swift
@@ -14,12 +14,18 @@ enum WebSurfaceViewportScript {
       if (window.__klasPlusViewportPolicyInstalled) { return; }
       window.__klasPlusViewportPolicyInstalled = true;
       function publishViewport() {
-        var viewport = window.visualViewport;
-        var height = viewport ? viewport.height : window.innerHeight;
-        var offsetTop = viewport ? viewport.offsetTop : 0;
-        document.documentElement.style.setProperty('--klas-visual-viewport-height', height + 'px');
-        document.documentElement.style.setProperty('--klas-visual-viewport-offset-top', offsetTop + 'px');
-        window.dispatchEvent(new Event('resize'));
+        if (window.__klasPlusViewportPublishing) { return; }
+        window.__klasPlusViewportPublishing = true;
+        try {
+          var viewport = window.visualViewport;
+          var height = viewport ? viewport.height : window.innerHeight;
+          var offsetTop = viewport ? viewport.offsetTop : 0;
+          document.documentElement.style.setProperty('--klas-visual-viewport-height', height + 'px');
+          document.documentElement.style.setProperty('--klas-visual-viewport-offset-top', offsetTop + 'px');
+          window.dispatchEvent(new Event('resize'));
+        } finally {
+          window.__klasPlusViewportPublishing = false;
+        }
       }
       if (window.visualViewport) {
         window.visualViewport.addEventListener('resize', publishViewport);

--- a/iosApp/iosApp/WebViewContainer.swift
+++ b/iosApp/iosApp/WebViewContainer.swift
@@ -1,15 +1,66 @@
 import SwiftUI
 import WebKit
 
+struct WebSurfaceLayoutPolicy: Equatable {
+    var extendsUnderHomeIndicator: Bool
+
+    static let product = WebSurfaceLayoutPolicy(extendsUnderHomeIndicator: true)
+    static let embedded = WebSurfaceLayoutPolicy(extendsUnderHomeIndicator: false)
+}
+
+enum WebSurfaceViewportScript {
+    static let source = """
+    (function() {
+      if (window.__klasPlusViewportPolicyInstalled) { return; }
+      window.__klasPlusViewportPolicyInstalled = true;
+      function publishViewport() {
+        var viewport = window.visualViewport;
+        var height = viewport ? viewport.height : window.innerHeight;
+        var offsetTop = viewport ? viewport.offsetTop : 0;
+        document.documentElement.style.setProperty('--klas-visual-viewport-height', height + 'px');
+        document.documentElement.style.setProperty('--klas-visual-viewport-offset-top', offsetTop + 'px');
+        window.dispatchEvent(new Event('resize'));
+      }
+      if (window.visualViewport) {
+        window.visualViewport.addEventListener('resize', publishViewport);
+        window.visualViewport.addEventListener('scroll', publishViewport);
+      }
+      window.addEventListener('resize', publishViewport);
+      publishViewport();
+    })();
+    """
+}
+
 // 이미 생성된 WKWebView를 SwiftUI에 표시
 struct WebViewContainer: UIViewRepresentable {
     let webView: WKWebView
+    let accessibilityIdentifier: String?
+
+    init(webView: WKWebView, accessibilityIdentifier: String? = nil) {
+        self.webView = webView
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
 
     func makeUIView(context: Context) -> WKWebView {
-        webView
+        if let accessibilityIdentifier {
+            webView.accessibilityIdentifier = accessibilityIdentifier
+        }
+        return webView
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
         // SwiftUI 재렌더링에서 WKWebView를 재생성 하지 않음
+    }
+}
+
+extension View {
+    func webSurfaceLayout(_ policy: WebSurfaceLayoutPolicy = .product) -> some View {
+        Group {
+            if policy.extendsUnderHomeIndicator {
+                self.ignoresSafeArea(.container, edges: .bottom)
+            } else {
+                self
+            }
+        }
     }
 }

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -28,6 +28,7 @@ final class WebViewHolder: NSObject, ObservableObject {
     private let allowsInAppWeb: Bool
     private var activeDownloadTask: Task<Void, Never>?
     private var loadingLocalPdf = false
+    private var webContentTerminationRetryUsed = false
 
     static var websiteDataStore: WKWebsiteDataStore { .default() }
 
@@ -165,6 +166,7 @@ final class WebViewHolder: NSObject, ObservableObject {
 
     func load(_ urlString: String) {
         guard !isDisposed, let url = URL(string: urlString) else { return }
+        webContentTerminationRetryUsed = false
         webView.load(URLRequest(url: url))
     }
 
@@ -175,6 +177,7 @@ final class WebViewHolder: NSObject, ObservableObject {
 
     func reload() {
         guard !isDisposed, _webView != nil else { return }
+        webContentTerminationRetryUsed = false
         webView.reload()
     }
 
@@ -216,6 +219,7 @@ final class WebViewHolder: NSObject, ObservableObject {
     func dispose() {
         guard !isDisposed else { return }
         isDisposed = true
+        webContentTerminationRetryUsed = false
         suppressJavaScriptAlertContaining = nil
         onSuppressedJavaScriptAlert = nil
         bridgeAdapter?.dispose()
@@ -235,6 +239,11 @@ final class WebViewHolder: NSObject, ObservableObject {
         javaScriptAlertCompletion = nil
         javaScriptAlertMessage = nil
         navigationState = WebNavigationState(loadPhase: .disposed)
+    }
+
+    func applyWebpagePreferences(_ preferences: WKWebpagePreferences) {
+        guard allowsInAppWeb else { return }
+        preferences.preferredContentMode = .mobile
     }
 
     func handleDecidePolicy(urlString: String, isMainFrame: Bool) -> Bool {
@@ -282,6 +291,7 @@ final class WebViewHolder: NSObject, ObservableObject {
 
     fileprivate func navigationDidFinish(url: String?) {
         guard !isDisposed, let view = _webView else { return }
+        webContentTerminationRetryUsed = false
         let finished = url ?? view.url?.absoluteString ?? ""
         navigationState = WebNavigationState(
             loadPhase: .ready(url: finished),
@@ -429,6 +439,20 @@ final class WebViewHolder: NSObject, ObservableObject {
         )
     }
 
+    func handleWebContentProcessDidTerminate() {
+        guard !isDisposed, let view = _webView else { return }
+        if webContentTerminationRetryUsed {
+            navigationState = WebNavigationState(
+                loadPhase: .failed(url: view.url?.absoluteString, category: .unknown),
+                canGoBack: view.canGoBack,
+                canGoForward: view.canGoForward
+            )
+            return
+        }
+        webContentTerminationRetryUsed = true
+        view.reload()
+    }
+
     private func startDownload(_ request: FileTransferRequest) {
         guard activeDownloadTask == nil else { return }
         activeDownloadTask = Task { @MainActor [weak self] in
@@ -553,12 +577,14 @@ private final class NavigationRelay: NSObject, WKNavigationDelegate {
     func webView(
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+        preferences: WKWebpagePreferences,
+        decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
     ) {
+        owner?.applyWebpagePreferences(preferences)
         let urlString = navigationAction.request.url?.absoluteString ?? ""
         let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
         let allow = owner?.handleDecidePolicy(urlString: urlString, isMainFrame: isMainFrame) ?? false
-        decisionHandler(allow ? .allow : .cancel)
+        decisionHandler(allow ? .allow : .cancel, preferences)
     }
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
@@ -596,6 +622,10 @@ private final class NavigationRelay: NSObject, WKNavigationDelegate {
         withError error: Error
     ) {
         owner?.navigationDidFail(url: webView.url?.absoluteString, error: error)
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        owner?.handleWebContentProcessDidTerminate()
     }
 }
 

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -21,6 +21,7 @@ final class WebViewHolder: NSObject, ObservableObject {
     private lazy var navigationRelay = NavigationRelay(owner: self)
     private lazy var uiRelay = UIRelay(owner: self)
     private let trustedOrigins = TrustedOriginPolicy(trustedOrigins: TrustedOriginPolicy.companion.DEFAULT_TRUSTED_ORIGINS)
+    private let klasContentOrigins = KlasContentOriginPolicy()
     private let fileTransferPolicy = FileTransferPolicy.companion.create()
     private let navigator: IosExternalNavigator
     private let filePicker: IosFilePicker
@@ -145,6 +146,7 @@ final class WebViewHolder: NSObject, ObservableObject {
 
     var suppressJavaScriptAlertContaining: String?
     var onSuppressedJavaScriptAlert: (() -> Void)?
+    var onWebContentProcessDidTerminate: (() -> Void)?
 
     func confirmJavaScriptAlert() {
         let completion = javaScriptAlertCompletion
@@ -222,6 +224,7 @@ final class WebViewHolder: NSObject, ObservableObject {
         webContentTerminationRetryUsed = false
         suppressJavaScriptAlertContaining = nil
         onSuppressedJavaScriptAlert = nil
+        onWebContentProcessDidTerminate = nil
         bridgeAdapter?.dispose()
         bridgeAdapter = nil
         cancelDownload()
@@ -239,11 +242,6 @@ final class WebViewHolder: NSObject, ObservableObject {
         javaScriptAlertCompletion = nil
         javaScriptAlertMessage = nil
         navigationState = WebNavigationState(loadPhase: .disposed)
-    }
-
-    func applyWebpagePreferences(_ preferences: WKWebpagePreferences) {
-        guard allowsInAppWeb else { return }
-        preferences.preferredContentMode = .mobile
     }
 
     func handleDecidePolicy(urlString: String, isMainFrame: Bool) -> Bool {
@@ -454,6 +452,7 @@ final class WebViewHolder: NSObject, ObservableObject {
             return
         }
         webContentTerminationRetryUsed = true
+        onWebContentProcessDidTerminate?()
         view.reload()
     }
 
@@ -519,12 +518,7 @@ final class WebViewHolder: NSObject, ObservableObject {
 
     private func isAllowedInAppWeb(_ raw: String) -> Bool {
         guard allowsInAppWeb else { return false }
-        guard let allowed = ExternalNavigationPolicy(maximumLength: 2048).resolve(rawValue: raw)
-            as? ExternalNavigationResolutionAllowed
-        else {
-            return false
-        }
-        return allowed.destination is ExternalDestinationWeb
+        return klasContentOrigins.isTrustedUrl(url: raw)
     }
 
     private func presentShareSheet(url: URL, deleteWhenDone: Bool) {
@@ -595,7 +589,6 @@ private final class NavigationRelay: NSObject, WKNavigationDelegate {
         preferences: WKWebpagePreferences,
         decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
     ) {
-        owner?.applyWebpagePreferences(preferences)
         let urlString = navigationAction.request.url?.absoluteString ?? ""
         let isMainFrame = navigationAction.targetFrame?.isMainFrame ?? true
         let allow = owner?.handleDecidePolicy(urlString: urlString, isMainFrame: isMainFrame) ?? false

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -25,6 +25,7 @@ final class WebViewHolder: NSObject, ObservableObject {
     private let navigator: IosExternalNavigator
     private let filePicker: IosFilePicker
     private let fileTransfer: IosFileTransfer
+    private let allowsInAppWeb: Bool
     private var activeDownloadTask: Task<Void, Never>?
     private var loadingLocalPdf = false
 
@@ -40,11 +41,13 @@ final class WebViewHolder: NSObject, ObservableObject {
     init(
         navigator: IosExternalNavigator = IosExternalNavigator.companion.system(),
         filePicker: IosFilePicker = IosFilePicker(),
-        fileTransfer: IosFileTransfer = IosFileTransfer()
+        fileTransfer: IosFileTransfer = IosFileTransfer(),
+        allowsInAppWeb: Bool = false
     ) {
         self.navigator = navigator
         self.filePicker = filePicker
         self.fileTransfer = fileTransfer
+        self.allowsInAppWeb = allowsInAppWeb
         super.init()
         fileTransfer.onProgress = { [weak self] fileName, fraction in
             self?.downloadProgress = DownloadProgressState(fileName: fileName, fraction: fraction)
@@ -110,7 +113,7 @@ final class WebViewHolder: NSObject, ObservableObject {
         handler: BridgeCommandHandler,
         synchronousHandler: SynchronousBridgeCommandHandler? = nil
     ) -> WebViewHolder {
-        let holder = WebViewHolder()
+        let holder = WebViewHolder(allowsInAppWeb: surface == .linkView)
         holder.installBridge(
             surface: surface,
             handler: handler,
@@ -244,15 +247,18 @@ final class WebViewHolder: NSObject, ObservableObject {
         if trustedOrigins.isTrustedUrl(url: urlString) {
             return true
         }
+        if isAllowedInAppWeb(urlString) {
+            return true
+        }
 
         openExternal(urlString)
         return false
     }
 
-    fileprivate func handleCreateWindow(urlString: String?) {
+    func handleCreateWindow(urlString: String?) {
         guard !isDisposed else { return }
         guard let urlString, !urlString.isEmpty else { return }
-        if trustedOrigins.isTrustedUrl(url: urlString) {
+        if trustedOrigins.isTrustedUrl(url: urlString) || isAllowedInAppWeb(urlString) {
             load(urlString)
         } else {
             openExternal(urlString)
@@ -282,6 +288,14 @@ final class WebViewHolder: NSObject, ObservableObject {
             canGoBack: view.canGoBack,
             canGoForward: view.canGoForward
         )
+        if let script = pageReadyScript(for: finished) {
+            evaluate(script)
+        }
+    }
+
+    func pageReadyScript(for url: String) -> WebScript? {
+        guard allowsInAppWeb, url.contains("notice.jsp") else { return nil }
+        return KlasWebAutomationScripts.shared.makeNoticeScrollable()
     }
 
     func handleNavigationResponse(
@@ -462,6 +476,16 @@ final class WebViewHolder: NSObject, ObservableObject {
         if result is PlatformActionResultSuccess {
             lastExternalURL = raw
         }
+    }
+
+    private func isAllowedInAppWeb(_ raw: String) -> Bool {
+        guard allowsInAppWeb else { return false }
+        guard let allowed = ExternalNavigationPolicy(maximumLength: 2048).resolve(rawValue: raw)
+            as? ExternalNavigationResolutionAllowed
+        else {
+            return false
+        }
+        return allowed.destination is ExternalDestinationWeb
     }
 
     private func presentShareSheet(url: URL, deleteWhenDone: Bool) {

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -139,6 +139,9 @@ final class WebViewHolder: NSObject, ObservableObject {
         })
     }
 
+    var suppressJavaScriptAlertContaining: String?
+    var onSuppressedJavaScriptAlert: (() -> Void)?
+
     func confirmJavaScriptAlert() {
         let completion = javaScriptAlertCompletion
         javaScriptAlertCompletion = nil
@@ -147,6 +150,11 @@ final class WebViewHolder: NSObject, ObservableObject {
     }
 
     func presentJavaScriptAlert(message: String, completion: @escaping () -> Void) {
+        if let marker = suppressJavaScriptAlertContaining, message.contains(marker) {
+            completion()
+            onSuppressedJavaScriptAlert?()
+            return
+        }
         javaScriptAlertCompletion?()
         javaScriptAlertCompletion = completion
         javaScriptAlertMessage = message
@@ -205,6 +213,8 @@ final class WebViewHolder: NSObject, ObservableObject {
     func dispose() {
         guard !isDisposed else { return }
         isDisposed = true
+        suppressJavaScriptAlertContaining = nil
+        onSuppressedJavaScriptAlert = nil
         bridgeAdapter?.dispose()
         bridgeAdapter = nil
         cancelDownload()

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -62,6 +62,13 @@ final class WebViewHolder: NSObject, ObservableObject {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = Self.websiteDataStore
         configuration.applicationNameForUserAgent = Self.iosAppUserAgentToken
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: WebSurfaceViewportScript.source,
+                injectionTime: .atDocumentEnd,
+                forMainFrameOnly: true
+            )
+        )
         bridgeAdapter?.install(into: configuration)
         let created = WKWebView(frame: .zero, configuration: configuration)
         created.navigationDelegate = navigationRelay
@@ -148,6 +155,11 @@ final class WebViewHolder: NSObject, ObservableObject {
     func load(_ urlString: String) {
         guard !isDisposed, let url = URL(string: urlString) else { return }
         webView.load(URLRequest(url: url))
+    }
+
+    func loadHTML(_ html: String, baseURL: URL) {
+        guard !isDisposed else { return }
+        webView.loadHTMLString(html, baseURL: baseURL)
     }
 
     func reload() {

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -274,7 +274,7 @@ final class WebViewHolder: NSObject, ObservableObject {
         }
     }
 
-    fileprivate func navigationDidStart(url: String?) {
+    func navigationDidStart(url: String?) {
         guard !isDisposed, let view = _webView else { return }
         if loadingLocalPdf {
             loadingLocalPdf = false
@@ -340,6 +340,7 @@ final class WebViewHolder: NSObject, ObservableObject {
             if accepted {
                 startDownload(request)
             }
+            restoreCommittedNavigationIfLoading()
             return .cancel
         }
 
@@ -347,6 +348,7 @@ final class WebViewHolder: NSObject, ObservableObject {
             if isAcceptedDownload(response) {
                 startDownload(makeDownloadRequest(response))
             }
+            restoreCommittedNavigationIfLoading()
             return .cancel
         }
         clearInlinePdf()
@@ -407,15 +409,17 @@ final class WebViewHolder: NSObject, ObservableObject {
         )
     }
 
-    fileprivate func navigationDidFail(url: String?, error: Error) {
+    func navigationDidFail(url: String?, error: Error) {
         guard !isDisposed, let view = _webView else { return }
         let nsError = error as NSError
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+            restoreCommittedNavigationIfLoading()
             return
         }
         // 다운로드, 외부 이동으로 내비게이션을 끊으면 WebKit이 102를 남긴다.
         if nsError.code == 102,
            nsError.domain == "WebKitErrorDomain" || nsError.domain == WKError.errorDomain {
+            restoreCommittedNavigationIfLoading()
             return
         }
         let category: WebNavFailureCategory
@@ -461,6 +465,17 @@ final class WebViewHolder: NSObject, ObservableObject {
             let result = await self.fileTransfer.download(request: request)
             self.handleDownloadResult(result)
         }
+    }
+
+    private func restoreCommittedNavigationIfLoading() {
+        guard !isDisposed, let view = _webView else { return }
+        guard case .loading = navigationState.loadPhase else { return }
+        let url = view.url?.absoluteString ?? ""
+        navigationState = WebNavigationState(
+            loadPhase: url.isEmpty ? .idle : .ready(url: url),
+            canGoBack: view.canGoBack,
+            canGoForward: view.canGoForward
+        )
     }
 
     private func handleCompletedFile(_ url: URL) {

--- a/iosApp/iosApp/iOSApp.swift
+++ b/iosApp/iosApp/iOSApp.swift
@@ -4,7 +4,14 @@ import SwiftUI
 struct iOSApp: App {
     var body: some Scene {
         WindowGroup {
-            StartupRootView()
+            Group {
+                if M6011UITestConfiguration.isEnabled {
+                    M6011FixtureRootView()
+                        .environment(\.dynamicTypeSize, M6011UITestConfiguration.dynamicTypeSize)
+                } else {
+                    StartupRootView()
+                }
+            }
                 .tint(KlasTheme.primary)
                 .background(KlasTheme.background)
         }

--- a/iosApp/iosAppTests/IosFilePortsTests.swift
+++ b/iosApp/iosAppTests/IosFilePortsTests.swift
@@ -89,6 +89,52 @@ final class IosFilePortsTests: XCTestCase {
         XCTAssertNil(defaultHolder.pageReadyScript(for: "https://www.kw.ac.kr/ko/life/notice.jsp"))
     }
 
+    func testInAppWebHolderPrefersMobileContentMode() {
+        let inApp = WebViewHolder(allowsInAppWeb: true)
+        defer { inApp.dispose() }
+        XCTAssertEqual(inApp.webView.configuration.defaultWebpagePreferences.preferredContentMode, .mobile)
+        let inAppPreferences = WKWebpagePreferences()
+        inAppPreferences.preferredContentMode = .desktop
+        inApp.applyWebpagePreferences(inAppPreferences)
+        XCTAssertEqual(inAppPreferences.preferredContentMode, .mobile)
+
+        let linkHolder = WebViewHolder.withLegacyBridge(
+            surface: .linkView,
+            handler: AcceptingBridgeCommandHandler()
+        )
+        defer { linkHolder.dispose() }
+        XCTAssertEqual(linkHolder.webView.configuration.defaultWebpagePreferences.preferredContentMode, .mobile)
+
+        let defaultHolder = WebViewHolder()
+        defer { defaultHolder.dispose() }
+        XCTAssertEqual(
+            defaultHolder.webView.configuration.defaultWebpagePreferences.preferredContentMode,
+            .recommended
+        )
+        let defaultPreferences = WKWebpagePreferences()
+        defaultPreferences.preferredContentMode = .desktop
+        defaultHolder.applyWebpagePreferences(defaultPreferences)
+        XCTAssertEqual(defaultPreferences.preferredContentMode, .desktop)
+    }
+
+    func testWebContentProcessTerminationReloadsOnceThenFails() {
+        let holder = WebViewHolder()
+        defer { holder.dispose() }
+        _ = holder.webView
+
+        holder.handleWebContentProcessDidTerminate()
+        XCTAssertFalse(holder.isFailed)
+
+        holder.handleWebContentProcessDidTerminate()
+        XCTAssertTrue(holder.isFailed)
+        XCTAssertFalse(holder.isLoading)
+        if case let .failed(_, category) = holder.navigationState.loadPhase {
+            XCTAssertEqual(category, .unknown)
+        } else {
+            XCTFail("expected failed load phase after second WebContent termination")
+        }
+    }
+
     func testDownloadDispatchIsSingleFlightAndInlinePdfHandling() throws {
         let transfer = RecordingFileTransfer()
         let dispatched = expectation(description: "downloads dispatched to FileTransfer")

--- a/iosApp/iosAppTests/IosFilePortsTests.swift
+++ b/iosApp/iosAppTests/IosFilePortsTests.swift
@@ -38,6 +38,57 @@ final class IosFilePortsTests: XCTestCase {
         XCTAssertTrue(holder.handleDecidePolicy(urlString: "https://klasplus.yuntae.in/feed", isMainFrame: true))
     }
 
+    func testInAppWebHolderLoadsUniversityNoticeInsteadOfSafari() {
+        let opener = RecordingUrlOpener()
+        let holder = WebViewHolder(
+            navigator: IosExternalNavigator(opener: opener),
+            allowsInAppWeb: true
+        )
+        defer { holder.dispose() }
+        let notice = "https://www.kw.ac.kr/ko/life/notice.jsp"
+
+        XCTAssertTrue(holder.handleDecidePolicy(urlString: notice, isMainFrame: true))
+        XCTAssertNil(holder.lastExternalURL)
+        XCTAssertTrue(opener.opened.isEmpty)
+        holder.handleCreateWindow(urlString: notice)
+        XCTAssertNil(holder.lastExternalURL)
+        XCTAssertTrue(opener.opened.isEmpty)
+
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "mailto:help@example.com", isMainFrame: true))
+        XCTAssertEqual(holder.lastExternalURL, "mailto:help@example.com")
+        XCTAssertEqual(opener.opened, ["mailto:help@example.com"])
+
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "javascript:alert(1)", isMainFrame: true))
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "intent://settings", isMainFrame: true))
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "file:///tmp/secret", isMainFrame: true))
+        XCTAssertEqual(holder.lastExternalURL, "mailto:help@example.com")
+        XCTAssertEqual(opener.opened, ["mailto:help@example.com"])
+    }
+
+    func testLinkViewBridgeHolderAllowsInAppWebAndNoticeScrollScript() {
+        let holder = WebViewHolder.withLegacyBridge(
+            surface: .linkView,
+            handler: AcceptingBridgeCommandHandler()
+        )
+        defer { holder.dispose() }
+
+        XCTAssertTrue(
+            holder.handleDecidePolicy(
+                urlString: "https://www.kw.ac.kr/ko/life/notice.jsp",
+                isMainFrame: true
+            )
+        )
+        XCTAssertNil(holder.lastExternalURL)
+        XCTAssertEqual(
+            holder.pageReadyScript(for: "https://www.kw.ac.kr/ko/life/notice.jsp")?.reveal(),
+            KlasWebAutomationScripts.shared.makeNoticeScrollable().reveal()
+        )
+        XCTAssertNil(holder.pageReadyScript(for: "https://www.kw.ac.kr/ko/life/facility11.jsp"))
+        let defaultHolder = WebViewHolder()
+        defer { defaultHolder.dispose() }
+        XCTAssertNil(defaultHolder.pageReadyScript(for: "https://www.kw.ac.kr/ko/life/notice.jsp"))
+    }
+
     func testDownloadDispatchIsSingleFlightAndInlinePdfHandling() throws {
         let transfer = RecordingFileTransfer()
         let dispatched = expectation(description: "downloads dispatched to FileTransfer")

--- a/iosApp/iosAppTests/IosFilePortsTests.swift
+++ b/iosApp/iosAppTests/IosFilePortsTests.swift
@@ -61,8 +61,9 @@ final class IosFilePortsTests: XCTestCase {
         XCTAssertFalse(holder.handleDecidePolicy(urlString: "javascript:alert(1)", isMainFrame: true))
         XCTAssertFalse(holder.handleDecidePolicy(urlString: "intent://settings", isMainFrame: true))
         XCTAssertFalse(holder.handleDecidePolicy(urlString: "file:///tmp/secret", isMainFrame: true))
-        XCTAssertEqual(holder.lastExternalURL, "mailto:help@example.com")
-        XCTAssertEqual(opener.opened, ["mailto:help@example.com"])
+        XCTAssertFalse(holder.handleDecidePolicy(urlString: "https://example.com/help", isMainFrame: true))
+        XCTAssertEqual(holder.lastExternalURL, "https://example.com/help")
+        XCTAssertEqual(opener.opened, ["mailto:help@example.com", "https://example.com/help"])
     }
 
     func testLinkViewBridgeHolderAllowsInAppWebAndNoticeScrollScript() {
@@ -87,34 +88,6 @@ final class IosFilePortsTests: XCTestCase {
         let defaultHolder = WebViewHolder()
         defer { defaultHolder.dispose() }
         XCTAssertNil(defaultHolder.pageReadyScript(for: "https://www.kw.ac.kr/ko/life/notice.jsp"))
-    }
-
-    func testInAppWebHolderPrefersMobileContentMode() {
-        let inApp = WebViewHolder(allowsInAppWeb: true)
-        defer { inApp.dispose() }
-        XCTAssertEqual(inApp.webView.configuration.defaultWebpagePreferences.preferredContentMode, .mobile)
-        let inAppPreferences = WKWebpagePreferences()
-        inAppPreferences.preferredContentMode = .desktop
-        inApp.applyWebpagePreferences(inAppPreferences)
-        XCTAssertEqual(inAppPreferences.preferredContentMode, .mobile)
-
-        let linkHolder = WebViewHolder.withLegacyBridge(
-            surface: .linkView,
-            handler: AcceptingBridgeCommandHandler()
-        )
-        defer { linkHolder.dispose() }
-        XCTAssertEqual(linkHolder.webView.configuration.defaultWebpagePreferences.preferredContentMode, .mobile)
-
-        let defaultHolder = WebViewHolder()
-        defer { defaultHolder.dispose() }
-        XCTAssertEqual(
-            defaultHolder.webView.configuration.defaultWebpagePreferences.preferredContentMode,
-            .recommended
-        )
-        let defaultPreferences = WKWebpagePreferences()
-        defaultPreferences.preferredContentMode = .desktop
-        defaultHolder.applyWebpagePreferences(defaultPreferences)
-        XCTAssertEqual(defaultPreferences.preferredContentMode, .desktop)
     }
 
     func testWebContentProcessTerminationReloadsOnceThenFails() {

--- a/iosApp/iosAppTests/IosFilePortsTests.swift
+++ b/iosApp/iosAppTests/IosFilePortsTests.swift
@@ -135,6 +135,41 @@ final class IosFilePortsTests: XCTestCase {
         }
     }
 
+    func testDownloadInterceptClearsLoadingState() throws {
+        let transfer = RecordingFileTransfer()
+        let holder = WebViewHolder(
+            navigator: IosExternalNavigator(opener: RecordingUrlOpener()),
+            fileTransfer: transfer
+        )
+        defer { holder.dispose() }
+        _ = holder.webView
+        holder.navigationDidStart(url: "https://klas.kw.ac.kr/std/file")
+        XCTAssertTrue(holder.isLoading)
+
+        let attachmentPdf = try XCTUnwrap(
+            HTTPURLResponse(
+                url: URL(string: "https://klas.kw.ac.kr/std/file")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: [
+                    "Content-Type": "application/octet-stream",
+                    "Content-Disposition": "attachment; filename=\"week15.pdf\"",
+                ]
+            )
+        )
+        XCTAssertEqual(
+            holder.handleNavigationResponse(attachmentPdf, isMainFrame: true, canShowMIMEType: false),
+            .cancel
+        )
+        XCTAssertFalse(holder.isLoading)
+
+        holder.navigationDidFail(
+            url: "https://klas.kw.ac.kr/std/file",
+            error: NSError(domain: "WebKitErrorDomain", code: 102)
+        )
+        XCTAssertFalse(holder.isLoading)
+    }
+
     func testDownloadDispatchIsSingleFlightAndInlinePdfHandling() throws {
         let transfer = RecordingFileTransfer()
         let dispatched = expectation(description: "downloads dispatched to FileTransfer")

--- a/iosApp/iosAppTests/IosHomeHostTests.swift
+++ b/iosApp/iosAppTests/IosHomeHostTests.swift
@@ -175,16 +175,14 @@ final class IosHomeHostTests: XCTestCase {
         model.handleKlasNavigation(
             WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/cmn/frame/Frame.do"))
         )
-        XCTAssertTrue(model.didOpenLecture)
-        XCTAssertTrue(model.isOpeningLecture)
+        XCTAssertEqual(model.bootstrap, .opening)
         XCTAssertEqual(
             model.klasHolder.suppressJavaScriptAlertContaining,
             LectureScreenModel.bootstrapLectureErrorMarker
         )
 
         model.handleOpenLectureWindowExpired()
-        XCTAssertTrue(model.didOpenLecture)
-        XCTAssertFalse(model.isOpeningLecture)
+        XCTAssertEqual(model.bootstrap, .finished)
         XCTAssertNil(model.klasHolder.suppressJavaScriptAlertContaining)
     }
 
@@ -208,19 +206,16 @@ final class IosHomeHostTests: XCTestCase {
         model.handleKlasNavigation(
             WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/cmn/frame/Frame.do"))
         )
-        XCTAssertTrue(model.didOpenLecture)
-        XCTAssertTrue(model.isOpeningLecture)
+        XCTAssertEqual(model.bootstrap, .opening)
 
         model.klasHolder.handleWebContentProcessDidTerminate()
-        XCTAssertFalse(model.didOpenLecture)
-        XCTAssertFalse(model.isOpeningLecture)
+        XCTAssertEqual(model.bootstrap, .idle)
         XCTAssertNil(model.klasHolder.suppressJavaScriptAlertContaining)
 
         model.handleKlasNavigation(
             WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/cmn/frame/Frame.do"))
         )
-        XCTAssertTrue(model.didOpenLecture)
-        XCTAssertTrue(model.isOpeningLecture)
+        XCTAssertEqual(model.bootstrap, .opening)
     }
 
     @MainActor
@@ -245,11 +240,10 @@ final class IosHomeHostTests: XCTestCase {
         model.handleKlasNavigation(
             WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/LctrumHomeStdPage.do"))
         )
-        XCTAssertTrue(model.didOpenLecture)
-        XCTAssertFalse(model.isOpeningLecture)
+        XCTAssertEqual(model.bootstrap, .finished)
 
         model.prepareLectureBootstrapAfterWebContentTermination()
-        XCTAssertTrue(model.didOpenLecture)
+        XCTAssertEqual(model.bootstrap, .finished)
     }
 
     func testWindowWidthClassKeepsResponsiveBoundaries() {

--- a/iosApp/iosAppTests/IosHomeHostTests.swift
+++ b/iosApp/iosAppTests/IosHomeHostTests.swift
@@ -22,6 +22,30 @@ final class IosHomeHostTests: XCTestCase {
         XCTAssertEqual(holder.webView.scrollView.contentInset, .zero)
     }
 
+    func testWebViewHolderKeepsViewportAndIdentityPoliciesStable() {
+        let holder = WebViewHolder.withLegacyBridge(
+            surface: .home,
+            handler: AcceptingBridgeCommandHandler()
+        )
+        defer { holder.dispose() }
+
+        let first = holder.webView
+        let second = holder.webView
+        XCTAssertTrue(first === second)
+        XCTAssertEqual(first.scrollView.keyboardDismissMode, .interactive)
+        XCTAssertTrue(WebSurfaceViewportScript.source.contains("visualViewport"))
+        XCTAssertTrue(WebSurfaceViewportScript.source.contains("klas-visual-viewport-height"))
+        XCTAssertTrue(WebSurfaceLayoutPolicy.product.extendsUnderHomeIndicator)
+        XCTAssertFalse(WebSurfaceLayoutPolicy.embedded.extendsUnderHomeIndicator)
+    }
+
+    func testWindowWidthClassKeepsResponsiveBoundaries() {
+        XCTAssertEqual(AppWindowWidthClass.classify(width: 599), .compact)
+        XCTAssertEqual(AppWindowWidthClass.classify(width: 600), .medium)
+        XCTAssertEqual(AppWindowWidthClass.classify(width: 839), .medium)
+        XCTAssertEqual(AppWindowWidthClass.classify(width: 840), .expanded)
+    }
+
     @MainActor
     func testHomeTabUrlsMatchAndroid() {
         XCTAssertEqual(

--- a/iosApp/iosAppTests/IosHomeHostTests.swift
+++ b/iosApp/iosAppTests/IosHomeHostTests.swift
@@ -323,6 +323,19 @@ final class IosHomeHostTests: XCTestCase {
     }
 
     @MainActor
+    func testUniversityNoticeOpenPagePushesInAppLink() {
+        let coordinator = makeHomeCoordinator()
+        defer { coordinator.dispose() }
+        let notice = "https://www.kw.ac.kr/ko/life/notice.jsp?mode=view"
+
+        coordinator.openWeb(url: notice)
+        XCTAssertEqual(coordinator.path.count, 1)
+
+        coordinator.openWeb(url: "javascript:alert(1)")
+        XCTAssertEqual(coordinator.path.count, 1)
+    }
+
+    @MainActor
     private func makeHomeCoordinator() -> HomeCoordinator {
         let suite = "com.icecream.kwklasplus.test.home.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/iosApp/iosAppTests/IosHomeHostTests.swift
+++ b/iosApp/iosAppTests/IosHomeHostTests.swift
@@ -39,6 +39,58 @@ final class IosHomeHostTests: XCTestCase {
         XCTAssertFalse(WebSurfaceLayoutPolicy.embedded.extendsUnderHomeIndicator)
     }
 
+    func testJavaScriptAlertCompletionStaysOnThePresentingHolder() {
+        let primary = WebViewHolder()
+        let secondary = WebViewHolder()
+        defer {
+            primary.dispose()
+            secondary.dispose()
+        }
+
+        var primaryConfirmed = false
+        var secondaryConfirmed = false
+        primary.presentJavaScriptAlert(message: "ui") { primaryConfirmed = true }
+        secondary.presentJavaScriptAlert(message: "klas") { secondaryConfirmed = true }
+
+        primary.confirmJavaScriptAlert()
+        XCTAssertTrue(primaryConfirmed)
+        XCTAssertNil(primary.javaScriptAlertMessage)
+        XCTAssertFalse(secondaryConfirmed)
+        XCTAssertEqual(secondary.javaScriptAlertMessage, "klas")
+
+        secondary.confirmJavaScriptAlert()
+        XCTAssertTrue(secondaryConfirmed)
+        XCTAssertNil(secondary.javaScriptAlertMessage)
+    }
+
+    func testJavaScriptAlertSuppressionCompletesWithoutPresenting() {
+        let holder = WebViewHolder()
+        defer { holder.dispose() }
+
+        var suppressedCount = 0
+        var presented = false
+        holder.suppressJavaScriptAlertContaining = LectureScreenModel.bootstrapLectureErrorMarker
+        holder.onSuppressedJavaScriptAlert = { suppressedCount += 1 }
+
+        holder.presentJavaScriptAlert(message: "오류가 발생하였습니다.") { presented = true }
+        XCTAssertEqual(suppressedCount, 1)
+        XCTAssertTrue(presented)
+        XCTAssertNil(holder.javaScriptAlertMessage)
+
+        presented = false
+        holder.presentJavaScriptAlert(message: "다른 안내") { presented = true }
+        XCTAssertEqual(suppressedCount, 1)
+        XCTAssertEqual(holder.javaScriptAlertMessage, "다른 안내")
+        XCTAssertFalse(presented)
+        holder.confirmJavaScriptAlert()
+        XCTAssertTrue(presented)
+    }
+
+    func testBootstrapLectureErrorMatcher() {
+        XCTAssertTrue(LectureScreenModel.isBootstrapLectureError("오류가 발생하였습니다."))
+        XCTAssertFalse(LectureScreenModel.isBootstrapLectureError("다른 안내"))
+    }
+
     func testWindowWidthClassKeepsResponsiveBoundaries() {
         XCTAssertEqual(AppWindowWidthClass.classify(width: 599), .compact)
         XCTAssertEqual(AppWindowWidthClass.classify(width: 600), .medium)

--- a/iosApp/iosAppTests/IosHomeHostTests.swift
+++ b/iosApp/iosAppTests/IosHomeHostTests.swift
@@ -35,6 +35,7 @@ final class IosHomeHostTests: XCTestCase {
         XCTAssertEqual(first.scrollView.keyboardDismissMode, .interactive)
         XCTAssertTrue(WebSurfaceViewportScript.source.contains("visualViewport"))
         XCTAssertTrue(WebSurfaceViewportScript.source.contains("klas-visual-viewport-height"))
+        XCTAssertTrue(WebSurfaceViewportScript.source.contains("__klasPlusViewportPublishing"))
         XCTAssertTrue(WebSurfaceLayoutPolicy.product.extendsUnderHomeIndicator)
         XCTAssertFalse(WebSurfaceLayoutPolicy.embedded.extendsUnderHomeIndicator)
     }
@@ -63,6 +64,70 @@ final class IosHomeHostTests: XCTestCase {
         XCTAssertNil(secondary.javaScriptAlertMessage)
     }
 
+    func testJavaScriptAlertPresentationKeepsStickyHolderUntilDismissed() {
+        let primary = WebViewHolder()
+        let secondary = WebViewHolder()
+        defer {
+            primary.dispose()
+            secondary.dispose()
+        }
+        primary.presentJavaScriptAlert(message: "ui") {}
+        secondary.presentJavaScriptAlert(message: "klas") {}
+
+        let first = WebJavaScriptAlertPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: true,
+            sticky: nil
+        )
+        XCTAssertTrue(first === primary)
+
+        let sticky = WebJavaScriptAlertPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: true,
+            sticky: primary
+        )
+        XCTAssertTrue(sticky === primary)
+
+        primary.confirmJavaScriptAlert()
+        let queued = WebJavaScriptAlertPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: true,
+            sticky: primary
+        )
+        XCTAssertTrue(queued === secondary)
+    }
+
+    func testJavaScriptAlertPresentationIgnoresDisabledSecondary() {
+        let primary = WebViewHolder()
+        let secondary = WebViewHolder()
+        defer {
+            primary.dispose()
+            secondary.dispose()
+        }
+        secondary.presentJavaScriptAlert(message: "klas") {}
+
+        XCTAssertNil(
+            WebJavaScriptAlertPresentation.holder(
+                primary: primary,
+                secondary: secondary,
+                secondaryEnabled: false,
+                sticky: nil
+            )
+        )
+
+        primary.presentJavaScriptAlert(message: "ui") {}
+        let visible = WebJavaScriptAlertPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: false,
+            sticky: nil
+        )
+        XCTAssertTrue(visible === primary)
+    }
+
     func testJavaScriptAlertSuppressionCompletesWithoutPresenting() {
         let holder = WebViewHolder()
         defer { holder.dispose() }
@@ -89,6 +154,102 @@ final class IosHomeHostTests: XCTestCase {
     func testBootstrapLectureErrorMatcher() {
         XCTAssertTrue(LectureScreenModel.isBootstrapLectureError("오류가 발생하였습니다."))
         XCTAssertFalse(LectureScreenModel.isBootstrapLectureError("다른 안내"))
+    }
+
+    @MainActor
+    func testOpenLectureWindowExpiryEndsSuppressionWithoutSecondCall() {
+        let coordinator = makeHomeCoordinator()
+        defer { coordinator.dispose() }
+        let model = LectureScreenModel(
+            subjectId: "TEST001",
+            subjectName: "테스트강의",
+            yearSemester: "2026,1",
+            sessionToken: SecretValue.companion.of(value: "session"),
+            coordinator: coordinator
+        )
+        defer {
+            model.uiHolder.dispose()
+            model.klasHolder.dispose()
+        }
+
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/cmn/frame/Frame.do"))
+        )
+        XCTAssertTrue(model.didOpenLecture)
+        XCTAssertTrue(model.isOpeningLecture)
+        XCTAssertEqual(
+            model.klasHolder.suppressJavaScriptAlertContaining,
+            LectureScreenModel.bootstrapLectureErrorMarker
+        )
+
+        model.handleOpenLectureWindowExpired()
+        XCTAssertTrue(model.didOpenLecture)
+        XCTAssertFalse(model.isOpeningLecture)
+        XCTAssertNil(model.klasHolder.suppressJavaScriptAlertContaining)
+    }
+
+    @MainActor
+    func testWebContentTerminationResetsLectureBootstrapBeforeLctrumHome() {
+        let coordinator = makeHomeCoordinator()
+        defer { coordinator.dispose() }
+        let model = LectureScreenModel(
+            subjectId: "TEST001",
+            subjectName: "테스트강의",
+            yearSemester: "2026,1",
+            sessionToken: SecretValue.companion.of(value: "session"),
+            coordinator: coordinator
+        )
+        defer {
+            model.uiHolder.dispose()
+            model.klasHolder.dispose()
+        }
+        _ = model.klasHolder.webView
+
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/cmn/frame/Frame.do"))
+        )
+        XCTAssertTrue(model.didOpenLecture)
+        XCTAssertTrue(model.isOpeningLecture)
+
+        model.klasHolder.handleWebContentProcessDidTerminate()
+        XCTAssertFalse(model.didOpenLecture)
+        XCTAssertFalse(model.isOpeningLecture)
+        XCTAssertNil(model.klasHolder.suppressJavaScriptAlertContaining)
+
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/cmn/frame/Frame.do"))
+        )
+        XCTAssertTrue(model.didOpenLecture)
+        XCTAssertTrue(model.isOpeningLecture)
+    }
+
+    @MainActor
+    func testWebContentTerminationDoesNotResetAfterLectureHome() {
+        let coordinator = makeHomeCoordinator()
+        defer { coordinator.dispose() }
+        let model = LectureScreenModel(
+            subjectId: "TEST001",
+            subjectName: "테스트강의",
+            yearSemester: "2026,1",
+            sessionToken: SecretValue.companion.of(value: "session"),
+            coordinator: coordinator
+        )
+        defer {
+            model.uiHolder.dispose()
+            model.klasHolder.dispose()
+        }
+
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/cmn/frame/Frame.do"))
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/LctrumHomeStdPage.do"))
+        )
+        XCTAssertTrue(model.didOpenLecture)
+        XCTAssertFalse(model.isOpeningLecture)
+
+        model.prepareLectureBootstrapAfterWebContentTermination()
+        XCTAssertTrue(model.didOpenLecture)
     }
 
     func testWindowWidthClassKeepsResponsiveBoundaries() {

--- a/iosApp/iosAppUITests/M6011UiTests.swift
+++ b/iosApp/iosAppUITests/M6011UiTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+
+final class M6011UiTests: XCTestCase {
+    private var app: XCUIApplication!
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        app = XCUIApplication()
+        app.launchArguments = ["-m6011-ui-test"]
+        if name.contains("RemainAccessibleAtLargeType") {
+            app.launchEnvironment["M6011_DYNAMIC_TYPE"] =
+                ProcessInfo.processInfo.environment["M6011_DYNAMIC_TYPE"] ?? "accessibility3"
+        } else if let dynamicType = ProcessInfo.processInfo.environment["M6011_DYNAMIC_TYPE"] {
+            app.launchEnvironment["M6011_DYNAMIC_TYPE"] = dynamicType
+        }
+        app.launch()
+    }
+
+    override func tearDown() {
+        XCUIDevice.shared.orientation = .portrait
+        app = nil
+        super.tearDown()
+    }
+
+    func testWebSurfaceAndNativeControlsRemainAvailableAfterRotation() {
+        let webSurface = app.descendants(matching: .any)["m6011_web_surface"]
+        XCTAssertTrue(webSurface.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForButton("m6011_sheet_button").isHittable)
+
+        XCUIDevice.shared.orientation = .landscapeLeft
+        XCTAssertTrue(webSurface.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForButton("m6011_alert_button").isHittable)
+
+        XCUIDevice.shared.orientation = .portrait
+        XCTAssertTrue(webSurface.waitForExistence(timeout: 5))
+        XCTAssertTrue(waitForButton("m6011_download_button").isHittable)
+    }
+
+    func testKeyboardInputUsesResizedWebSurface() {
+        let input = app.textFields["웹 입력"]
+        XCTAssertTrue(input.waitForExistence(timeout: 5))
+        input.tap()
+        XCTAssertTrue(input.isHittable)
+        let nativeControls = app.descendants(matching: .any)["m6011_native_controls"]
+        XCTAssertTrue(nativeControls.waitForExistence(timeout: 5))
+        XCTAssertTrue(nativeControls.isHittable)
+    }
+
+    func testNativeOverlaysArePresentedOnceAndRemainAccessibleAtLargeType() {
+        waitForButton("m6011_sheet_button").tap()
+        let sheet = app.descendants(matching: .any)["selection_bottom_sheet"]
+        XCTAssertTrue(sheet.waitForExistence(timeout: 3))
+        XCTAssertTrue(app.staticTexts["환경 확인"].waitForExistence(timeout: 2))
+        let firstOption = app.buttons["selection_option_0"]
+        XCTAssertTrue(firstOption.waitForExistence(timeout: 2))
+        XCTAssertEqual(app.buttons.matching(identifier: "selection_option_0").count, 1)
+        XCTAssertTrue(firstOption.isHittable)
+        XCTAssertTrue(app.buttons["selection_option_1"].isHittable)
+        firstOption.tap()
+        waitUntilGone(firstOption)
+
+        waitForButton("m6011_alert_button").tap()
+        let alert = app.alerts["환경 확인"]
+        XCTAssertTrue(alert.waitForExistence(timeout: 3))
+        XCTAssertTrue(alert.buttons["확인"].isHittable)
+        alert.buttons["확인"].tap()
+        waitUntilGone(alert)
+
+        waitForButton("m6011_download_button").tap()
+        let downloadOverlay = app.descendants(matching: .any)["download_progress_overlay"]
+        XCTAssertTrue(downloadOverlay.waitForExistence(timeout: 3))
+        let cancel = app.buttons["취소"]
+        XCTAssertTrue(cancel.waitForExistence(timeout: 2))
+        XCTAssertEqual(app.buttons.matching(NSPredicate(format: "label == %@", "취소")).count, 1)
+        XCTAssertTrue(cancel.isHittable)
+        cancel.tap()
+        waitUntilGone(downloadOverlay)
+    }
+
+    func testWebInputAndControlsExposeAccessibilityLabels() {
+        XCTAssertTrue(app.textFields["웹 입력"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["웹 하단 내비게이션"].exists)
+        XCTAssertTrue(waitForButton("m6011_sheet_button").isHittable)
+        XCTAssertTrue(waitForButton("m6011_alert_button").isHittable)
+        XCTAssertTrue(waitForButton("m6011_download_button").isHittable)
+    }
+
+    private func waitForButton(_ identifier: String) -> XCUIElement {
+        let button = app.buttons[identifier]
+        XCTAssertTrue(button.waitForExistence(timeout: 5))
+        return button
+    }
+
+    private func waitUntilGone(_ element: XCUIElement, timeout: TimeInterval = 3) {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: element
+        )
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: timeout), .completed)
+    }
+}

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
@@ -15,8 +15,16 @@ object KlasWebAutomationScripts {
         require(intervalMs > 0)
         val call = openLecture(yearSemester, subjectId).reveal()
         return WebScript(
-            "(function(){function go(n){if(window.appModule&&typeof appModule.goLctrum==='function'){" +
-                "$call;return;}if(n>0)setTimeout(function(){go(n-1);},$intervalMs);}go($maxRetries);})();",
+            "(function(){function go(n){" +
+                "if(!(window.appModule&&typeof appModule.goLctrum==='function')){" +
+                "if(n>0)setTimeout(function(){go(n-1);},$intervalMs);return;}" +
+                "var failed=false;var orig=window.alert;" +
+                "window.alert=function(msg){" +
+                "if(String(msg||'').indexOf('오류가 발생')!==-1){failed=true;return;}" +
+                "return orig.apply(this,arguments);};" +
+                "try{$call}finally{window.alert=orig;}" +
+                "if(failed&&n>0)setTimeout(function(){go(n-1);},$intervalMs);" +
+                "}go($maxRetries);})();",
         )
     }
 

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
@@ -16,15 +16,9 @@ object KlasWebAutomationScripts {
         val call = openLecture(yearSemester, subjectId).reveal()
         return WebScript(
             "(function(){function go(n){" +
-                "if(!(window.appModule&&typeof appModule.goLctrum==='function')){" +
-                "if(n>0)setTimeout(function(){go(n-1);},$intervalMs);return;}" +
-                "var failed=false;var orig=window.alert;" +
-                "window.alert=function(msg){" +
-                "if(String(msg||'').indexOf('오류가 발생')!==-1){failed=true;return;}" +
-                "return orig.apply(this,arguments);};" +
-                "try{$call}finally{window.alert=orig;}" +
-                "if(failed&&n>0)setTimeout(function(){go(n-1);},$intervalMs);" +
-                "}go($maxRetries);})();",
+                "if(window.appModule&&typeof appModule.goLctrum==='function'){$call;return;}" +
+                "if(n>0)setTimeout(function(){go(n-1);},$intervalMs);}" +
+                "go($maxRetries);})();",
         )
     }
 

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScriptsTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScriptsTest.kt
@@ -15,12 +15,12 @@ class WebAutomationScriptsTest {
     }
 
     @Test
-    fun openLectureWhenReadyWrapsCallInRetryLoop() {
+    fun openLectureWhenReadyWaitsForGoLctrumThenCallsOnce() {
         val script = KlasWebAutomationScripts.openLectureWhenReady("2026,1", "SUBJ'01").reveal()
         assertTrue(script.contains("appModule.goLctrum(\"2026,1\",\"SUBJ'01\");"))
         assertTrue(script.contains("typeof appModule.goLctrum==='function'"))
-        assertTrue(script.contains("indexOf('오류가 발생')"))
         assertTrue(script.contains("setTimeout"))
+        assertTrue(!script.contains("window.alert"))
         assertTrue(script.startsWith("(function(){"))
         assertTrue(script.endsWith("go(20);})();"))
     }

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScriptsTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScriptsTest.kt
@@ -19,6 +19,7 @@ class WebAutomationScriptsTest {
         val script = KlasWebAutomationScripts.openLectureWhenReady("2026,1", "SUBJ'01").reveal()
         assertTrue(script.contains("appModule.goLctrum(\"2026,1\",\"SUBJ'01\");"))
         assertTrue(script.contains("typeof appModule.goLctrum==='function'"))
+        assertTrue(script.contains("indexOf('오류가 발생')"))
         assertTrue(script.contains("setTimeout"))
         assertTrue(script.startsWith("(function(){"))
         assertTrue(script.endsWith("go(20);})();"))

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/platform/IosExternalNavigator.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/platform/IosExternalNavigator.kt
@@ -35,7 +35,12 @@ class IosExternalNavigator(
 
     companion object {
         fun system(): IosExternalNavigator = IosExternalNavigator { url ->
-            UIApplication.sharedApplication.openURL(url)
+            UIApplication.sharedApplication.openURL(
+                url,
+                options = emptyMap<Any?, Any>(),
+                completionHandler = null,
+            )
+            true
         }
     }
 }


### PR DESCRIPTION
## Summary

M6-011. WKWebView 컨테이너가 compact/regular, 세로/가로, 키보드 표시에서도 웹 본문과 네이티브 overlay를 가리거나 holder를 다시 만들지 않게 맞춥니다.

제품 경로에서 같이 수정한 버그:
- 홈 공지 `openPage(www.kw.ac.kr)`는 Safari가 아니라 Link WKWebView
- 강의 홈 `goLctrum` 부트스트랩 오류는 진입 전까지 억제 후 재시도
- iPad 공지 로딩 스피너는 holder 상태를 따라감

## Changes

- WebView: UIKit 자동 content inset을 끄고 `container` safe area의 bottom만 선택적으로 무시합니다. keyboard safe area는 남겨 WKWebView frame이 IME에 맞춰 줄어들게 합니다.
- Viewport: document-end policy script가 `visualViewport` resize/scroll을 `--klas-visual-viewport-*` CSS 변수와 `resize` 이벤트로 전달합니다. 회전·trait 변경은 holder identity를 바꾸지 않습니다.
- Overlay: toolbar·sheet·toast·download는 SwiftUI safe area 안에 두고, overlay가 떠 있는 동안 뒤 WebView는 hit-test와 VoiceOver 트리에서 제외합니다. 홈 toast는 빈 `GeometryReader`가 탭을 가로채지 않습니다.
- Accessibility: 로그인/시트 버튼은 Dynamic Type에 맞춰 높이가 늘고, `SelectionBottomSheet`는 포커스를 heading/첫 항목으로 보냅니다.
- 공지: Link surface만 허용된 http(s)를 같은 WKWebView에 로드하도록 수정합니다. iOS 18에서 막히던 `openURL`도 새 API로 바꿉니다.
- 강의: `goLctrum` 부트스트랩 오류는 JS `window.alert` 패치로 막을 수 없어, 강의 홈 진입 전까지 네이티브에서 억제하고 재시도합니다. dual holder의 JS alert completion은 해당 holder에 묶입니다.

## Test plan

- `./gradlew :shared:iosSimulatorArm64Test --tests 'com.icecream.kwklasplus.core.web.WebAutomationScriptsTest'`
- `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -testPlan M6-011 test`
- iPhone 세로→가로→세로: 홈 하단 탭·본문이 잘리지 않고 holder가 유지되는지
- 홈/게시판 입력 필드에 키보드를 올렸을 때 입력란과 하단 내비게이션이 가려지지 않는지
- 학기 선택 sheet, JS alert, 다운로드 overlay가 한 번만 뜨고 WebView 탭을 막는지. toast는 뒤 WebView 탭을 막지 않는지
- Dynamic Type 크게 / VoiceOver에서 시트 항목과 로그인 필드가 잘리지 않는지
- 홈 공지(`www.kw.ac.kr`)가 Safari가 아니라 인앱 Link WebView로 열리고, 로드 끝나면 스피너가 사라지는지 (iPhone + iPad)
- 강의 홈 진입 시 부트스트랩 `오류가 발생하였습니다.` alert 없이 강의가 열리는지

iOS

https://github.com/user-attachments/assets/be2c95e3-76e8-4bcf-a260-75482fa111b7

iPad

https://github.com/user-attachments/assets/c7537a9f-1b8c-4d8a-87a5-c9a4ef4839f2
