### PR TITLE
fix: 로그인 실패 후 잘못된 credential 자동 재사용 방지

### DIFF
--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/LoginActivity.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/LoginActivity.kt
@@ -90,6 +90,18 @@ class LoginActivity : AppCompatActivity() {
                 )
             }
         }
+
+        if (savedInstanceState == null) {
+            lifecycleScope.launch {
+                val savedAccountId = runCatching {
+                    appDependencies.credentialStore.loadAccountId()
+                }.getOrNull()
+                if (!savedAccountId.isNullOrBlank()) {
+                    studentId = savedAccountId
+                    onboardingVisible = false
+                }
+            }
+        }
     }
 
     private fun submitLogin() {

--- a/iosApp/iosApp/AuthSessionController.swift
+++ b/iosApp/iosApp/AuthSessionController.swift
@@ -173,7 +173,7 @@ final class AuthSessionController: ObservableObject {
                 }
             }
         case .goToLogin:
-            phase = .needsCredentials
+            loadAccountIdForLogin()
         }
     }
 
@@ -189,7 +189,7 @@ final class AuthSessionController: ObservableObject {
 
     private func handleLoadedCredential(_ credential: StoredCredential?) {
         guard let credential else {
-            phase = .needsCredentials
+            loadAccountIdForLogin()
             return
         }
         activeCredential = credential
@@ -260,6 +260,7 @@ final class AuthSessionController: ObservableObject {
         }
         if let failed = result as? LoginResultFailed {
             if failed.failure is AuthFailureInvalidCredentials {
+                activeCredential = nil
                 // Android는 JS alert 메시지를 먼저 보여주고, 이후 Failed(null)은 무시한다.
                 if case .blocked(.invalidCredentials) = phase { return }
                 phase = .blocked(.invalidCredentials(nil))
@@ -290,6 +291,22 @@ final class AuthSessionController: ObservableObject {
         authRuntime.loadCredential { [weak self] credential in
             Task { @MainActor in
                 self?.handleLoadedCredential(credential)
+            }
+        }
+    }
+
+    private func loadAccountIdForLogin() {
+        authRuntime.loadAccountId { [weak self] accountId in
+            Task { @MainActor in
+                guard let self else { return }
+                self.activeCredential = nil
+                self.loginState = LoginUiState(
+                    onboardingVisible: accountId == nil,
+                    studentId: accountId ?? "",
+                    password: "",
+                    agreementAccepted: false
+                )
+                self.phase = .needsCredentials
             }
         }
     }

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -124,7 +124,7 @@ final class LectureScreenModel: ObservableObject {
             if isLoading { isLoading = false }
         }
         if url.contains("LctrumHomeStdPage.do") {
-            klasHolder.evaluate(KlasWebAutomationScripts.shared.collectLectureBoardPaths())
+            klasHolder.evaluate(KlasWebAutomationScripts.shared.collectLectureBoardPaths(maxRetries: 20, intervalMs: 250))
             if showingKlas { showingKlas = false }
         }
     }
@@ -177,7 +177,7 @@ final class LectureScreenModel: ObservableObject {
             self.pendingBoardNavigation = nil
             self.coordinator?.showToast("게시판 정보를 불러오지 못했어요. 강의 화면을 새로고침한 뒤 다시 시도해주세요.")
         }
-        klasHolder.evaluate(KlasWebAutomationScripts.shared.collectLectureBoardPaths())
+        klasHolder.evaluate(KlasWebAutomationScripts.shared.collectLectureBoardPaths(maxRetries: 20, intervalMs: 250))
         if !wasWaiting {
             coordinator?.showToast("게시판 정보를 불러오는 중이에요.")
         }

--- a/iosApp/iosAppTests/AuthSessionControllerTests.swift
+++ b/iosApp/iosAppTests/AuthSessionControllerTests.swift
@@ -46,6 +46,25 @@ final class AuthSessionControllerTests: XCTestCase {
         }
     }
 
+    func testStartPrefillsRetainedAccountIdWithoutPassword() async {
+        let suite = "com.icecream.kwklasplus.test.auth.prefill.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defaults.set("2020123456", forKey: "kwID")
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let controller = AuthSessionController(
+            authRuntime: IosAuthRuntime.companion.create(defaults: defaults),
+            networkPath: FakeNetworkPathChecker(satisfied: true)
+        )
+
+        controller.start()
+        await waitUntil { controller.phase == .needsCredentials }
+
+        XCTAssertEqual(controller.loginState.studentId, "2020123456")
+        XCTAssertEqual(controller.loginState.password, "")
+        XCTAssertFalse(controller.loginState.onboardingVisible)
+    }
+
     func testHomeSessionExpiredClearsSessionBeforeReturningToLogin() async {
         let suite = "com.icecream.kwklasplus.test.auth.expired.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suite)!

--- a/shared/src/androidHostTest/kotlin/com/icecream/kwklasplus/core/auth/AndroidCredentialStoreTest.kt
+++ b/shared/src/androidHostTest/kotlin/com/icecream/kwklasplus/core/auth/AndroidCredentialStoreTest.kt
@@ -1,0 +1,85 @@
+package com.icecream.kwklasplus.core.auth
+
+import com.icecream.kwklasplus.core.legacy.LegacyPreferenceKeys
+import com.icecream.kwklasplus.core.migration.LegacySecretRef
+import com.icecream.kwklasplus.core.migration.LegacySecretSource
+import com.icecream.kwklasplus.core.migration.SecureStoreMigrator
+import com.icecream.kwklasplus.core.migration.androidLoginCredentialMigrations
+import com.icecream.kwklasplus.core.platform.SecureKey
+import com.icecream.kwklasplus.core.platform.SecureStore
+import com.icecream.kwklasplus.core.security.SecretValue
+import com.icecream.kwklasplus.core.testing.InMemorySharedPreferences
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.coroutines.startCoroutine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AndroidCredentialStoreTest {
+    @Test
+    fun clearPasswordPreservesAccountIdAndRemovesLegacyFallbacks() = runCredentialStoreTest {
+        val preferences = InMemorySharedPreferences().apply {
+            edit()
+                .putString(LegacyPreferenceKeys.KW_ID, "2020123456")
+                .putString(LegacyPreferenceKeys.KW_PASSWORD, "legacy-password")
+                .commit()
+        }
+        val secrets = FakeSecureStore().apply {
+            write(SecureKey.ENCRYPTED_KLAS_PASSWORD, SecretValue.of("encrypted-password"))
+        }
+        val legacySource = FakeLegacySecretSource().apply {
+            androidLoginCredentialMigrations.forEach { migration ->
+                values[migration.source] = SecretValue.of("legacy-password")
+            }
+        }
+        val store = AndroidCredentialStore(
+            preferences,
+            secrets,
+            SecureStoreMigrator(legacySource, secrets),
+            legacySource,
+        )
+
+        store.clearPassword()
+
+        assertEquals("2020123456", store.loadAccountId())
+        assertNull(store.load())
+        assertNull(secrets.read(SecureKey.ENCRYPTED_KLAS_PASSWORD))
+        assertNull(preferences.getString(LegacyPreferenceKeys.KW_PASSWORD, null))
+        androidLoginCredentialMigrations.forEach { migration ->
+            assertNull(legacySource.values[migration.source])
+        }
+    }
+
+    private class FakeSecureStore : SecureStore {
+        private val values = mutableMapOf<SecureKey, SecretValue>()
+
+        override suspend fun read(key: SecureKey): SecretValue? = values[key]
+        override suspend fun write(key: SecureKey, value: SecretValue) {
+            values[key] = value
+        }
+        override suspend fun remove(key: SecureKey) {
+            values.remove(key)
+        }
+    }
+
+    private class FakeLegacySecretSource : LegacySecretSource {
+        val values = mutableMapOf<LegacySecretRef, SecretValue>()
+
+        override suspend fun read(reference: LegacySecretRef): SecretValue? = values[reference]
+        override suspend fun remove(reference: LegacySecretRef) {
+            values.remove(reference)
+        }
+    }
+}
+
+private fun <T> runCredentialStoreTest(block: suspend () -> T): T {
+    var outcome: Result<T>? = null
+    block.startCoroutine(object : Continuation<T> {
+        override val context = EmptyCoroutineContext
+        override fun resumeWith(result: Result<T>) {
+            outcome = result
+        }
+    })
+    return requireNotNull(outcome).getOrThrow()
+}

--- a/shared/src/androidMain/kotlin/com/icecream/kwklasplus/core/AndroidSharedDependencies.kt
+++ b/shared/src/androidMain/kotlin/com/icecream/kwklasplus/core/AndroidSharedDependencies.kt
@@ -106,6 +106,7 @@ class AndroidSharedDependencies(
 
     fun loginUseCase(webAuthDriver: WebAuthDriver) = LoginUseCase(
         prepareCredentialUseCase,
+        credentialStore,
         webAuthDriver,
         sessionCoordinator,
     )

--- a/shared/src/androidMain/kotlin/com/icecream/kwklasplus/core/auth/AndroidCredentialStore.kt
+++ b/shared/src/androidMain/kotlin/com/icecream/kwklasplus/core/auth/AndroidCredentialStore.kt
@@ -23,6 +23,9 @@ class AndroidCredentialStore(
         return StoredCredential(accountId, password)
     }
 
+    override suspend fun loadAccountId(): String? =
+        preferences.getString(LegacyPreferenceKeys.KW_ID, null)?.takeIf(String::isNotBlank)
+
     override suspend fun save(credential: StoredCredential) {
         val previousPassword = secureStore.read(SecureKey.ENCRYPTED_KLAS_PASSWORD)
         val previousAccountId = preferences.getString(LegacyPreferenceKeys.KW_ID, null)
@@ -58,6 +61,20 @@ class AndroidCredentialStore(
         androidLoginCredentialMigrations.forEach { migration ->
             runCatching { legacySource.remove(migration.source) }
         }
+    }
+
+    override suspend fun clearPassword() {
+        var failure: Throwable? = null
+        runCatching { secureStore.remove(SecureKey.ENCRYPTED_KLAS_PASSWORD) }
+            .onFailure { failure = it }
+        if (!preferences.edit().remove(LegacyPreferenceKeys.KW_PASSWORD).commit() && failure == null) {
+            failure = IllegalStateException("credential password clear failed")
+        }
+        androidLoginCredentialMigrations.forEach { migration ->
+            runCatching { legacySource.remove(migration.source) }
+                .onFailure { if (failure == null) failure = it }
+        }
+        failure?.let { throw it }
     }
 
     override suspend fun clear() {

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/auth/AuthModels.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/auth/AuthModels.kt
@@ -14,7 +14,9 @@ data class StoredCredential(
 
 interface CredentialStore {
     suspend fun load(): StoredCredential?
+    suspend fun loadAccountId(): String?
     suspend fun save(credential: StoredCredential)
+    suspend fun clearPassword()
     suspend fun clear()
 }
 

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/auth/LoginUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/auth/LoginUseCase.kt
@@ -71,6 +71,7 @@ class PrepareCredentialUseCase(
 
 class LoginUseCase(
     private val prepareCredential: PrepareCredentialUseCase,
+    private val credentialStore: CredentialStore,
     private val webAuthDriver: WebAuthDriver,
     private val sessionCoordinator: SessionCoordinator,
 ) {
@@ -81,6 +82,7 @@ class LoginUseCase(
         sessionCoordinator: SessionCoordinator,
     ) : this(
         PrepareCredentialUseCase(encryptionApi, credentialStore),
+        credentialStore,
         webAuthDriver,
         sessionCoordinator,
     )
@@ -96,7 +98,18 @@ class LoginUseCase(
 
     private suspend fun authenticate(credential: StoredCredential): LoginResult =
         when (val webResult = webAuthDriver.authenticate(credential)) {
-            is WebAuthResult.Failure -> failure(webResult.failure)
+            is WebAuthResult.Failure -> {
+                if (webResult.failure == AuthFailure.InvalidCredentials) {
+                    try {
+                        credentialStore.clearPassword()
+                        LoginResult.Failed(AuthFailure.InvalidCredentials)
+                    } catch (_: Throwable) {
+                        LoginResult.Failed(AuthFailure.Storage)
+                    }
+                } else {
+                    failure(webResult.failure)
+                }
+            }
             is WebAuthResult.SessionObserved -> when (val session = sessionCoordinator.observe(webResult.token)) {
                 is SessionResult.Active -> LoginResult.Authenticated(session.session)
                 else -> LoginResult.Failed(AuthFailure.Storage)

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/auth/LoginUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/auth/LoginUseCaseTest.kt
@@ -134,6 +134,50 @@ class LoginUseCaseTest {
         assertEquals(LoginResult.Failed(AuthFailure.Storage), storage)
     }
 
+    @Test
+    fun invalidCredentialsClearOnlyEncryptedPassword() = runLoginTest {
+        val stored = StoredCredential("2026000000", SecretValue.of("invalid-encrypted-password"))
+        val credentialStore = FakeCredentialStore().apply { credential = stored }
+        val useCase = useCase(
+            credentialStore = credentialStore,
+            webAuthDriver = WebAuthDriver { WebAuthResult.Failure(AuthFailure.InvalidCredentials) },
+        )
+
+        val result = useCase.resume(stored)
+
+        assertEquals(LoginResult.Failed(AuthFailure.InvalidCredentials), result)
+        assertNull(credentialStore.credential)
+        assertEquals("2026000000", credentialStore.loadAccountId())
+    }
+
+    @Test
+    fun invalidCredentialPasswordClearFailureIsStorageFailure() = runLoginTest {
+        val stored = StoredCredential("2026000000", SecretValue.of("invalid-encrypted-password"))
+        val credentialStore = FakeCredentialStore(failOnClearPassword = true).apply {
+            credential = stored
+        }
+        val useCase = useCase(
+            credentialStore = credentialStore,
+            webAuthDriver = WebAuthDriver { WebAuthResult.Failure(AuthFailure.InvalidCredentials) },
+        )
+
+        assertEquals(LoginResult.Failed(AuthFailure.Storage), useCase.resume(stored))
+        assertEquals(stored, credentialStore.credential)
+    }
+
+    @Test
+    fun networkFailureKeepsStoredCredentialForRetry() = runLoginTest {
+        val stored = StoredCredential("2026000000", SecretValue.of("encrypted-password"))
+        val credentialStore = FakeCredentialStore().apply { credential = stored }
+        val useCase = useCase(
+            credentialStore = credentialStore,
+            webAuthDriver = WebAuthDriver { WebAuthResult.Failure(AuthFailure.Network) },
+        )
+
+        assertEquals(LoginResult.Failed(AuthFailure.Network), useCase.resume(stored))
+        assertEquals(stored, credentialStore.credential)
+    }
+
     private fun useCase(
         credentialStore: FakeCredentialStore = FakeCredentialStore(),
         sessionStore: FakeSessionStore = FakeSessionStore(),
@@ -153,15 +197,27 @@ class LoginUseCaseTest {
 
     private class FakeCredentialStore(
         private val failOnSave: Boolean = false,
+        private val failOnClearPassword: Boolean = false,
     ) : CredentialStore {
+        var accountId: String? = null
         var credential: StoredCredential? = null
+            set(value) {
+                field = value
+                if (value != null) accountId = value.accountId
+            }
         override suspend fun load(): StoredCredential? = credential
+        override suspend fun loadAccountId(): String? = accountId
         override suspend fun save(credential: StoredCredential) {
             if (failOnSave) error("storage failure")
             this.credential = credential
         }
+        override suspend fun clearPassword() {
+            if (failOnClearPassword) error("password clear failure")
+            credential = null
+        }
         override suspend fun clear() {
             credential = null
+            accountId = null
         }
     }
 

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/auth/PrepareCredentialUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/auth/PrepareCredentialUseCaseTest.kt
@@ -61,9 +61,13 @@ class PrepareCredentialUseCaseTest {
     ) : CredentialStore {
         var credential: StoredCredential? = null
         override suspend fun load() = credential
+        override suspend fun loadAccountId(): String? = credential?.accountId
         override suspend fun save(credential: StoredCredential) {
             if (failSave) error("save failed")
             this.credential = credential
+        }
+        override suspend fun clearPassword() {
+            credential = null
         }
         override suspend fun clear() {
             credential = null

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosAuthRuntime.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosAuthRuntime.kt
@@ -24,6 +24,12 @@ class IosAuthRuntime(
         }
     }
 
+    fun loadAccountId(onResult: (String?) -> Unit) {
+        scope.launch {
+            onResult(runCatching { dependencies.credentialStore.loadAccountId() }.getOrNull())
+        }
+    }
+
     fun restoreSession(onResult: (SessionResult) -> Unit) {
         scope.launch {
             onResult(dependencies.sessionCoordinator.restore())

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
@@ -97,6 +97,7 @@ class IosSharedDependencies(
 
     fun loginUseCase(webAuthDriver: WebAuthDriver) = LoginUseCase(
         prepareCredentialUseCase,
+        credentialStore,
         webAuthDriver,
         sessionCoordinator,
     )

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/auth/IosCredentialStore.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/auth/IosCredentialStore.kt
@@ -17,6 +17,9 @@ class IosCredentialStore(
         return StoredCredential(accountId, password)
     }
 
+    override suspend fun loadAccountId(): String? =
+        defaults.stringForKey(LegacyPreferenceKeys.KW_ID)?.takeIf(String::isNotBlank)
+
     override suspend fun save(credential: StoredCredential) {
         val previousPassword = secureStore.read(SecureKey.ENCRYPTED_KLAS_PASSWORD)
         val previousAccountId = defaults.stringForKey(LegacyPreferenceKeys.KW_ID)
@@ -46,6 +49,17 @@ class IosCredentialStore(
             defaults.synchronize()
             throw cause
         }
+    }
+
+    override suspend fun clearPassword() {
+        var failure: Throwable? = null
+        runCatching { secureStore.remove(SecureKey.ENCRYPTED_KLAS_PASSWORD) }
+            .onFailure { failure = it }
+        defaults.removeObjectForKey(LegacyPreferenceKeys.KW_PASSWORD)
+        if (!defaults.synchronize() && failure == null) {
+            failure = IllegalStateException("credential password clear failed")
+        }
+        failure?.let { throw it }
     }
 
     override suspend fun clear() {

--- a/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/auth/IosCredentialStoreTest.kt
+++ b/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/auth/IosCredentialStoreTest.kt
@@ -31,6 +31,12 @@ class IosCredentialStoreTest {
         assertNull(defaults.stringForKey("kwPWD"))
         assertEquals(SecretValue.of("encrypted-pw"), secrets.read(SecureKey.ENCRYPTED_KLAS_PASSWORD))
 
+        store.clearPassword()
+        assertNull(store.load())
+        assertEquals("2020123456", store.loadAccountId())
+        assertNull(secrets.read(SecureKey.ENCRYPTED_KLAS_PASSWORD))
+
+        store.save(credential)
         store.clear()
         assertNull(store.load())
         assertNull(defaults.stringForKey("kwID"))


### PR DESCRIPTION
#16 - 로그인 실패(InvalidCredentials) 후에도 credential이 남아 재시작 시 자동 로그인을 재시도함
이슈 해결

## 변경 사항

- `InvalidCredentials` 발생 시 암호화된 KLAS 비밀번호만 삭제하도록 공통 인증 정책을 변경했습니다.
- 저장된 학번(`kwID`)은 유지합니다.
- Android와 iOS 로그인 화면에서 남은 학번을 자동으로 채우고 비밀번호는 비운 상태로 표시합니다.
- Network, Timeout, CAPTCHA 등 재시도 가능한 실패에서는 기존 credential을 유지합니다.

## 사용자 동작

1. 저장된 credential로 자동 로그인을 시도합니다.
2. 학번 또는 비밀번호 오류가 발생하면 저장된 암호화 비밀번호를 삭제합니다.
3. 로그인 화면으로 이동하며 기존 학번은 자동 입력됩니다.
4. 사용자는 비밀번호만 다시 입력할 수 있습니다.
5. 앱을 재시작해도 잘못된 비밀번호로 자동 로그인을 반복하지 않습니다.

## 테스트

- [x] `InvalidCredentials`에서 비밀번호만 삭제하고 학번은 유지
- [x] Network 실패에서 credential 유지
- [x] `:shared:testAndroidHostTest`
- [x] `:androidApp:testDebugUnitTest`

@lmmh202 iOS 디바이스에서 수정된 로그인 동작이 의도대로 작동하는지 테스트해주시면 감사하겠습니다!!