### PR TITLE
feat: iOS 앱 잠금 PIN, 생체인증과 설정 WebView 연동 (M7-001)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -15,7 +15,7 @@
 | M4 Android Web/Compose | 진행 중(7/8)   | Android 화면 전환 완료. legacy 자산 정리만 남음        |
 | M5 Android 기능 패리티      | **완료(7/7)** | QR·잠금·PIP·위젯·파일·테마 및 전체 Android 회귀 통과     |
 | M6 iOS 기본 경로           | 진행 중(9/11)  | M6-010 다운로드·외부 이동 완료. 파일 업로드 실계정 검증 남음. 다음: M6-011 UI 환경 |
-| M7 iOS 플랫폼 기능          | 미착수(0/7)    | M6 기본 경로 이후 진행                            |
+| M7 iOS 플랫폼 기능          | 진행 중(1/7)    | M7-001 앱 잠금 완료. 다음: M7-002 QR 출석 |
 
 ### M1 — 기존 계약 고정
 
@@ -143,8 +143,13 @@
 
 ### M7 — iOS 네이티브 기능 구현
 
-- [ ] **M7-001 (P0, L)** 앱 잠금·LocalAuthentication·Keychain
+- [x] **M7-001 (P0, L)** 앱 잠금·LocalAuthentication·Keychain
   - 작업: 네이티브 UI 구현 후 WebView의 settings 페이지 내 '앱 잠금' 관련 옵션 및 버튼 상태 연동
+  - 구현: `IosAppLockStore`(Keychain hash/salt, UserDefaults `a_l_e`/`b_m_e`), SwiftUI PIN(`SET`/`CHANGE`/`VERIFY`/`UNLOCK`), `scenePhase` + `AppLockPolicy`, Settings 브리지 콜백
+  - 검증:
+    - `./gradlew :shared:iosSimulatorArm64Test --tests 'com.icecream.kwklasplus.core.lock.IosAppLockCredentialCodecTest' --tests 'com.icecream.kwklasplus.core.web.IosWebCallbacksTest'`
+    - `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test -only-testing:iosAppTests/IosAppLockStoreTests -only-testing:iosAppTests/AppLockControllerTests`
+  - 남은 일: Face ID 활성화·UNLOCK은 실기기 검증
 - [ ] **M7-002 (P0, L)** QR 출석 스캐너
   - Depends on: M6-009
 - [ ] **M7-003 (P0, M)** iOS 온라인 강의 player·PIP 방식 결정

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -36,8 +36,8 @@
 | F-019 | QR 출석 | Android scanner port | AVFoundation/VisionKit port | P0 | Parity | 성공·실패·취소·중복 실행 포함 |
 | F-020 | 도서관 QR 조회 | 공통 API + Android UI | 공통 API + iOS UI | P1 | Parity | 캐시·밝기·IME·갱신 포함 |
 | F-021 | 홈 화면 도서관 위젯 | AppWidgetProvider | WidgetKit extension | P1 | Parity | 잠금·만료·테마 포함 |
-| F-022 | 앱 잠금 PIN | 공통 policy + Android lifecycle | 공통 policy + iOS scene phase | P0 | Parity | 업그레이드·위젯 예외 포함 |
-| F-023 | 생체인식 | Android biometric port | LocalAuthentication port | P0 | Parity | 성공·취소·미등록·미지원 포함 |
+| F-022 | 앱 잠금 PIN | 공통 policy + Android lifecycle | 공통 policy + iOS scene phase | P0 | Parity | iOS PIN SET/CHANGE/VERIFY/UNLOCK, Settings `getAppLockSettings`/`onAppLockSettingChanged`. hash/salt는 Keychain, 플래그는 UserDefaults `a_l_e`/`b_m_e`. 위젯 예외는 M7-006. (`IosAppLockStoreTests`, `AppLockControllerTests`) |
+| F-023 | 생체인식 | Android biometric port | LocalAuthentication port | P0 | Parity | `IosBiometrics` 성공·취소·미등록·미지원 매핑, Settings `onBiometricSettingChanged`. Face ID 실기기 검증 남음 |
 | F-024 | 설정/테마/버전 | 공통 Web/Compose + settings | 동일 | P1 | Parity | 재시작 persistence 포함. iOS `KlasTheme` 토큰은 Android `values`/`values-night` light·dark 쌍 |
 | F-025 | 다운로드 | Android DownloadManager/SAF | URLSession/files/share | P1 | Parity | cookie·MIME·filename·취소 포함. `inline` 파일명은 표시 가능 MIME이면 렌더링하고 `attachment`만 강제 다운로드. iOS는 single-flight로 중복 요청과 취소 완료 전 재진입을 거부 |
 | F-026 | 파일 선택/업로드 | Activity Result adapter | document/photo picker | P1 | Parity | 단일·다중·MIME·취소 포함. iOS M6-010: `UIDocumentPicker`와 계약 테스트는 있음. 실계정 업로드 검증은 후속 |

--- a/iosApp/iosApp/AppLockController.swift
+++ b/iosApp/iosApp/AppLockController.swift
@@ -1,0 +1,295 @@
+import Shared
+import SwiftUI
+import UIKit
+
+@MainActor
+final class AppLockController: ObservableObject {
+    enum Mode: String, Identifiable {
+        case unlock
+        case set
+        case change
+        case verify
+
+        var id: String { rawValue }
+    }
+
+    @Published var mode: Mode?
+    @Published private(set) var title = ""
+    @Published private(set) var description = ""
+    @Published private(set) var enteredDigits = 0
+    @Published private(set) var biometricVisible = false
+    @Published var toastMessage: String?
+
+    let store: IosAppLockStore
+
+    private let policy = AppLockPolicy()
+    private let biometrics = IosBiometrics()
+    private let canUseBiometrics: () -> Bool
+    private var input = ""
+    private var firstNewPassword: String?
+    private var oldPassword: String?
+    private var disabling = false
+    private var settingsCompletion: ((Bool) -> Void)?
+    private var toastTask: Task<Void, Never>?
+    private var didAutoPromptBiometric = false
+
+    init(
+        store: IosAppLockStore,
+        canUseBiometrics: @escaping () -> Bool = { IosBiometricAvailability.canAuthenticate() }
+    ) {
+        self.store = store
+        self.canUseBiometrics = canUseBiometrics
+    }
+
+    var canCancel: Bool { mode != .unlock }
+
+    func handleScenePhase(_ phase: ScenePhase) {
+        switch phase {
+        case .background:
+            let reduced = policy.reduce(
+                state: store.currentState(),
+                event: AppLockEventEnteredBackground.shared
+            )
+            store.isUnlocked = reduced.unlocked
+        case .active:
+            requestUnlockIfNeeded()
+        default:
+            break
+        }
+    }
+
+    func requestUnlockIfNeeded() {
+        let exempt = mode != nil
+        if policy.shouldRequestUnlock(state: store.currentState(), isExemptHost: exempt) {
+            present(.unlock, disabling: false, completion: nil)
+        }
+    }
+
+    func presentPasswordSetup(completion: @escaping (Bool) -> Void) {
+        present(store.hasPassword() ? .change : .set, disabling: false, completion: completion)
+    }
+
+    func presentVerifyToDisable(completion: @escaping (Bool) -> Void) {
+        present(.verify, disabling: true, completion: completion)
+    }
+
+    func cancel() {
+        guard canCancel else { return }
+        finishSettings(success: false)
+    }
+
+    func appendDigit(_ digit: Int) {
+        guard input.count < LockScreenMetrics.pinLength else { return }
+        input.append(String(digit))
+        enteredDigits = input.count
+        if input.count == LockScreenMetrics.pinLength {
+            confirmInput()
+        }
+    }
+
+    func deleteDigit() {
+        guard !input.isEmpty else { return }
+        input.removeLast()
+        enteredDigits = input.count
+    }
+
+    func promptUnlockBiometricIfNeeded() {
+        guard mode == .unlock, biometricVisible, !didAutoPromptBiometric else { return }
+        didAutoPromptBiometric = true
+        Task { await authenticateUnlock() }
+    }
+
+    func requestUnlockBiometric() {
+        Task { await authenticateUnlock() }
+    }
+
+    func authenticateEnableBiometrics() async -> PlatformActionResult {
+        await biometrics.authenticate(purpose: .enableBiometrics)
+    }
+
+    private func present(_ mode: Mode, disabling: Bool, completion: ((Bool) -> Void)?) {
+        self.disabling = disabling
+        settingsCompletion = completion
+        firstNewPassword = nil
+        oldPassword = nil
+        didAutoPromptBiometric = false
+        self.mode = mode
+        refreshChrome()
+    }
+
+    private func refreshChrome() {
+        switch mode {
+        case .unlock:
+            title = "앱 잠금"
+            description = "비밀번호 6자리를 입력해주세요."
+            biometricVisible = store.isBiometricEnabled() && canUseBiometrics()
+        case .set:
+            title = "비밀번호 설정"
+            description = firstNewPassword == nil
+                ? "새로운 비밀번호 6자리를 입력해주세요."
+                : "다시 한번 입력해주세요."
+            biometricVisible = false
+        case .change:
+            title = "비밀번호 변경"
+            if oldPassword == nil {
+                description = "현재 비밀번호를 입력해주세요."
+            } else if firstNewPassword == nil {
+                description = "새로운 비밀번호 6자리를 입력해주세요."
+            } else {
+                description = "다시 한번 입력해주세요."
+            }
+            biometricVisible = false
+        case .verify:
+            title = "비밀번호 확인"
+            description = "기존 비밀번호를 입력해주세요."
+            biometricVisible = false
+        case nil:
+            title = ""
+            description = ""
+            biometricVisible = false
+        }
+        clearInput()
+    }
+
+    private func confirmInput() {
+        guard input.count == LockScreenMetrics.pinLength else {
+            showToast("비밀번호 6자리를 입력해주세요.")
+            return
+        }
+        switch mode {
+        case .unlock:
+            verifyUnlock(input)
+        case .set:
+            setPassword(input)
+        case .change:
+            changePassword(input)
+        case .verify:
+            verifyExisting(input)
+        case nil:
+            break
+        }
+    }
+
+    private func verifyUnlock(_ value: String) {
+        if store.verifyPassword(input: value) {
+            unlockSuccess()
+        } else {
+            showToast("비밀번호가 일치하지 않습니다.")
+            clearInput()
+        }
+    }
+
+    private func setPassword(_ value: String) {
+        if firstNewPassword == nil {
+            firstNewPassword = value
+            refreshChrome()
+            return
+        }
+        if value != firstNewPassword {
+            showToast("비밀번호가 일치하지 않습니다. 처음부터 다시 시도해주세요.")
+            firstNewPassword = nil
+            refreshChrome()
+            return
+        }
+        store.savePassword(password: value)
+        store.setEnabled(enabled: true)
+        showToast("비밀번호가 설정되었습니다.")
+        Task { await completePasswordUpdate() }
+    }
+
+    private func changePassword(_ value: String) {
+        if oldPassword == nil {
+            if store.verifyPassword(input: value) {
+                oldPassword = value
+                refreshChrome()
+            } else {
+                showToast("현재 비밀번호가 일치하지 않습니다.")
+                clearInput()
+            }
+            return
+        }
+        if firstNewPassword == nil {
+            firstNewPassword = value
+            refreshChrome()
+            return
+        }
+        if value != firstNewPassword {
+            showToast("비밀번호가 일치하지 않습니다. 새로운 비밀번호부터 다시 입력해주세요.")
+            firstNewPassword = nil
+            refreshChrome()
+            return
+        }
+        store.savePassword(password: value)
+        showToast("비밀번호가 변경되었습니다.")
+        Task { await completePasswordUpdate() }
+    }
+
+    private func verifyExisting(_ value: String) {
+        if store.verifyPassword(input: value) {
+            if disabling {
+                store.setEnabled(enabled: false)
+            }
+            finishSettings(success: true)
+        } else {
+            showToast("비밀번호가 일치하지 않습니다.")
+            clearInput()
+        }
+    }
+
+    private func completePasswordUpdate() async {
+        if canUseBiometrics() {
+            let result = await biometrics.authenticate(
+                purpose: .enableBiometrics,
+                localizedReason: "생체인증을 사용하려면 인증이 필요합니다."
+            )
+            if result is PlatformActionResultSuccess {
+                store.setBiometricEnabled(enabled: true)
+                showToast("생체인증이 활성화되었습니다.")
+            }
+        }
+        finishSettings(success: true)
+    }
+
+    private func authenticateUnlock() async {
+        let result = await biometrics.authenticate(purpose: .unlockApp)
+        if result is PlatformActionResultSuccess {
+            unlockSuccess()
+        }
+    }
+
+    private func unlockSuccess() {
+        store.isUnlocked = true
+        mode = nil
+        settingsCompletion = nil
+        disabling = false
+    }
+
+    private func finishSettings(success: Bool) {
+        let completion = settingsCompletion
+        settingsCompletion = nil
+        disabling = false
+        mode = nil
+        completion?(success)
+    }
+
+    private func clearInput() {
+        input = ""
+        enteredDigits = 0
+    }
+
+    func showToast(_ message: String) {
+        toastMessage = message
+        UIAccessibility.post(notification: .announcement, argument: message)
+        toastTask?.cancel()
+        toastTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            if toastMessage == message {
+                toastMessage = nil
+            }
+        }
+    }
+}
+
+enum LockScreenMetrics {
+    static let pinLength = 6
+}

--- a/iosApp/iosApp/AppLockController.swift
+++ b/iosApp/iosApp/AppLockController.swift
@@ -23,8 +23,9 @@ final class AppLockController: ObservableObject {
     let store: IosAppLockStore
 
     private let policy = AppLockPolicy()
-    private let biometrics = IosBiometrics()
     private let canUseBiometrics: () -> Bool
+    private let isAppInBackgroundOverride: (() -> Bool)?
+    private let authenticateBiometrics: (BiometricPurpose, String?) async -> PlatformActionResult
     private var input = ""
     private var firstNewPassword: String?
     private var oldPassword: String?
@@ -32,29 +33,66 @@ final class AppLockController: ObservableObject {
     private var settingsCompletion: ((Bool) -> Void)?
     private var toastTask: Task<Void, Never>?
     private var didAutoPromptBiometric = false
+    private var isBiometricPromptActive = false
+    private var backgroundLockTask: Task<Void, Never>?
+    private let backgroundLockDelayNanos: UInt64
 
     init(
         store: IosAppLockStore,
-        canUseBiometrics: @escaping () -> Bool = { IosBiometricAvailability.canAuthenticate() }
+        canUseBiometrics: @escaping () -> Bool = { IosBiometricAvailability.canAuthenticate() },
+        isAppInBackground: (() -> Bool)? = nil,
+        backgroundLockDelayNanos: UInt64 = UInt64(AppLockPolicy.companion.BACKGROUND_LOCK_DELAY_MS) * 1_000_000,
+        authenticateBiometrics: ((BiometricPurpose, String?) async -> PlatformActionResult)? = nil
     ) {
         self.store = store
         self.canUseBiometrics = canUseBiometrics
+        self.isAppInBackgroundOverride = isAppInBackground
+        self.backgroundLockDelayNanos = backgroundLockDelayNanos
+        let biometrics = IosBiometrics()
+        self.authenticateBiometrics = authenticateBiometrics ?? { purpose, reason in
+            await biometrics.authenticate(purpose: purpose, localizedReason: reason)
+        }
     }
 
     var canCancel: Bool { mode != .unlock }
 
+    private func isProcessInBackground() -> Bool {
+        isAppInBackgroundOverride?() ?? (UIApplication.shared.applicationState == .background)
+    }
+
     func handleScenePhase(_ phase: ScenePhase) {
         switch phase {
         case .background:
-            let reduced = policy.reduce(
-                state: store.currentState(),
-                event: AppLockEventEnteredBackground.shared
-            )
-            store.isUnlocked = reduced.unlocked
+            guard !isBiometricPromptActive, isProcessInBackground() else { return }
+            scheduleBackgroundLock()
         case .active:
+            backgroundLockTask?.cancel()
+            backgroundLockTask = nil
+            guard !isBiometricPromptActive else { return }
             requestUnlockIfNeeded()
         default:
             break
+        }
+    }
+
+    private func scheduleBackgroundLock() {
+        backgroundLockTask?.cancel()
+        backgroundLockTask = Task { @MainActor in
+            do {
+                if backgroundLockDelayNanos > 0 {
+                    try await Task.sleep(nanoseconds: backgroundLockDelayNanos)
+                } else if Task.isCancelled {
+                    return
+                }
+                guard !isBiometricPromptActive, isProcessInBackground() else { return }
+                let reduced = policy.reduce(
+                    state: store.currentState(),
+                    event: AppLockEventEnteredBackground.shared
+                )
+                store.isUnlocked = reduced.unlocked
+            } catch {
+                return
+            }
         }
     }
 
@@ -104,7 +142,7 @@ final class AppLockController: ObservableObject {
     }
 
     func authenticateEnableBiometrics() async -> PlatformActionResult {
-        await biometrics.authenticate(purpose: .enableBiometrics)
+        await runBiometricPrompt { await authenticateBiometrics(.enableBiometrics, nil) }
     }
 
     private func present(_ mode: Mode, disabling: Bool, completion: ((Bool) -> Void)?) {
@@ -193,6 +231,7 @@ final class AppLockController: ObservableObject {
         }
         store.savePassword(password: value)
         store.setEnabled(enabled: true)
+        store.isUnlocked = true
         showToast("비밀번호가 설정되었습니다.")
         Task { await completePasswordUpdate() }
     }
@@ -238,10 +277,12 @@ final class AppLockController: ObservableObject {
 
     private func completePasswordUpdate() async {
         if canUseBiometrics() {
-            let result = await biometrics.authenticate(
-                purpose: .enableBiometrics,
-                localizedReason: "생체인증을 사용하려면 인증이 필요합니다."
-            )
+            let result = await runBiometricPrompt {
+                await authenticateBiometrics(
+                    .enableBiometrics,
+                    "생체인증을 사용하려면 인증이 필요합니다."
+                )
+            }
             if result is PlatformActionResultSuccess {
                 store.setBiometricEnabled(enabled: true)
                 showToast("생체인증이 활성화되었습니다.")
@@ -251,10 +292,18 @@ final class AppLockController: ObservableObject {
     }
 
     private func authenticateUnlock() async {
-        let result = await biometrics.authenticate(purpose: .unlockApp)
+        let result = await runBiometricPrompt { await authenticateBiometrics(.unlockApp, nil) }
         if result is PlatformActionResultSuccess {
             unlockSuccess()
         }
+    }
+
+    private func runBiometricPrompt(
+        _ body: () async -> PlatformActionResult
+    ) async -> PlatformActionResult {
+        isBiometricPromptActive = true
+        defer { isBiometricPromptActive = false }
+        return await body()
     }
 
     private func unlockSuccess() {

--- a/iosApp/iosApp/AppLockController.swift
+++ b/iosApp/iosApp/AppLockController.swift
@@ -292,4 +292,9 @@ final class AppLockController: ObservableObject {
 
 enum LockScreenMetrics {
     static let pinLength = 6
+
+    static func useTwoPane(width: CGFloat, height: CGFloat) -> Bool {
+        let widthClass = AppWindowWidthClass.classify(width: width)
+        return widthClass == .expanded || (widthClass == .medium && height < 600)
+    }
 }

--- a/iosApp/iosApp/HomeCoordinator.swift
+++ b/iosApp/iosApp/HomeCoordinator.swift
@@ -70,6 +70,7 @@ final class HomeCoordinator: ObservableObject {
     private var homeHost: HomeBridgeHostAdapter?
     private var toastTask: Task<Void, Never>?
     private var didStart = false
+    private weak var settingsWebHolder: WebViewHolder?
 
     var colorScheme: ColorScheme? {
         switch theme {
@@ -282,12 +283,18 @@ final class HomeCoordinator: ObservableObject {
         path.append(HomeDestination.settings)
     }
 
+    func attachSettingsWebView(_ holder: WebViewHolder) {
+        settingsWebHolder = holder
+    }
+
     func selectYearHakgi(_ value: String) {
         yearHakgi = value
         homeRuntime.saveYearHakgi(value: value)
         showYearHakgiPicker = false
         reloadHome()
-        homeHolder?.evaluate(IosWebCallbacks.shared.receiveYearHakgi(value: value))
+        let script = IosWebCallbacks.shared.receiveYearHakgi(value: value)
+        homeHolder?.evaluate(script)
+        settingsWebHolder?.evaluate(script)
     }
 
     func applyTheme(_ type: String) {

--- a/iosApp/iosApp/HomeRootView.swift
+++ b/iosApp/iosApp/HomeRootView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct HomeRootView: View {
     @StateObject private var coordinator: HomeCoordinator
+    @EnvironmentObject private var appLock: AppLockController
     private let onSessionExpired: () -> Void
 
     init(
@@ -106,7 +107,7 @@ struct HomeRootView: View {
                 coordinator: coordinator
             )
         case .settings:
-            SettingsView(coordinator: coordinator)
+            SettingsView(coordinator: coordinator, appLock: appLock)
         }
     }
 }

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSFaceIDUsageDescription</key>
+	<string>앱 잠금을 해제하기 위해 Face ID를 사용합니다.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 </dict>

--- a/iosApp/iosApp/IosBiometrics.swift
+++ b/iosApp/iosApp/IosBiometrics.swift
@@ -1,0 +1,86 @@
+import LocalAuthentication
+import Shared
+
+enum IosBiometricAvailability {
+    static func canAuthenticate() -> Bool {
+        var error: NSError?
+        return LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+    }
+
+    static func errorMessage() -> String? {
+        let context = LAContext()
+        var error: NSError?
+        if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
+            return nil
+        }
+        switch LAError.Code(rawValue: error?.code ?? 0) {
+        case .biometryNotAvailable:
+            return "이 기기는 생체 인증을 지원하지 않아요."
+        case .biometryNotEnrolled:
+            return "등록된 생체 정보가 없습니다. 기기 설정에서 생체 정보를 등록해주세요."
+        default:
+            return "현재 생체 인증을 사용할 수 없어요."
+        }
+    }
+}
+
+struct IosBiometrics {
+    func authenticate(
+        purpose: BiometricPurpose,
+        localizedReason: String? = nil
+    ) async -> PlatformActionResult {
+        let context = LAContext()
+        var error: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) else {
+            return Self.mapAvailability(error)
+        }
+        do {
+            let success = try await context.evaluatePolicy(
+                .deviceOwnerAuthenticationWithBiometrics,
+                localizedReason: localizedReason ?? Self.reason(for: purpose)
+            )
+            return success
+                ? PlatformActionResultSuccess()
+                : PlatformActionResultFailed(reason: "biometric_authentication_failed")
+        } catch let authError as LAError {
+            return Self.mapAuth(authError)
+        } catch {
+            return PlatformActionResultFailed(reason: "biometric_authentication_failed")
+        }
+    }
+
+    private static func reason(for purpose: BiometricPurpose) -> String {
+        switch purpose {
+        case .unlockApp, .disableAppLock:
+            return "앱 잠금 해제"
+        case .enableBiometrics:
+            return "생체인증 사용"
+        default:
+            return "생체인증"
+        }
+    }
+
+    private static func mapAvailability(_ error: NSError?) -> PlatformActionResult {
+        switch LAError.Code(rawValue: error?.code ?? 0) {
+        case .biometryNotEnrolled, .passcodeNotSet:
+            return PlatformActionResultPermissionRequired()
+        case .biometryNotAvailable:
+            return PlatformActionResultUnsupported()
+        default:
+            return PlatformActionResultFailed(reason: "biometric_unavailable")
+        }
+    }
+
+    private static func mapAuth(_ error: LAError) -> PlatformActionResult {
+        switch error.code {
+        case .userCancel, .appCancel, .systemCancel, .userFallback:
+            return PlatformActionResultCancelled()
+        case .biometryNotEnrolled, .passcodeNotSet:
+            return PlatformActionResultPermissionRequired()
+        case .biometryNotAvailable:
+            return PlatformActionResultUnsupported()
+        default:
+            return PlatformActionResultFailed(reason: "biometric_authentication_failed")
+        }
+    }
+}

--- a/iosApp/iosApp/LockScreenView.swift
+++ b/iosApp/iosApp/LockScreenView.swift
@@ -5,15 +5,40 @@ struct LockScreenView: View {
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 24) {
-                Spacer(minLength: 12)
-                lockSummary
-                Spacer(minLength: 12)
-                lockKeypad
+            GeometryReader { proxy in
+                let widthClass = AppWindowWidthClass.classify(width: proxy.size.width)
+                let useTwoPane = LockScreenMetrics.useTwoPane(
+                    width: proxy.size.width,
+                    height: proxy.size.height
+                )
+                let keyHeight = keypadKeyHeight(
+                    availableHeight: proxy.size.height,
+                    twoPane: useTwoPane
+                )
+
+                Group {
+                    if useTwoPane {
+                        HStack(spacing: 48) {
+                            lockSummary
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            lockKeypad(keyHeight: keyHeight)
+                                .frame(maxWidth: 440)
+                                .frame(maxWidth: .infinity)
+                        }
+                    } else {
+                        VStack(spacing: 24) {
+                            lockSummary
+                                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            lockKeypad(keyHeight: keyHeight)
+                                .frame(maxWidth: 440)
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+                }
+                .padding(.horizontal, horizontalPadding(widthClass))
+                .padding(.vertical, useTwoPane ? 16 : 24)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(KlasTheme.background.ignoresSafeArea())
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -23,6 +48,7 @@ struct LockScreenView: View {
                     }
                 }
             }
+            .toolbar(controller.canCancel ? .visible : .hidden, for: .navigationBar)
         }
         .interactiveDismissDisabled()
         .overlay(alignment: .bottom) { toast }
@@ -63,12 +89,12 @@ struct LockScreenView: View {
         }
     }
 
-    private var lockKeypad: some View {
+    private func lockKeypad(keyHeight: CGFloat) -> some View {
         VStack(spacing: 4) {
             ForEach([[1, 2, 3], [4, 5, 6], [7, 8, 9]], id: \.first) { row in
                 HStack(spacing: 4) {
                     ForEach(row, id: \.self) { number in
-                        keypadButton(label: String(number)) {
+                        keypadButton(label: String(number), height: keyHeight) {
                             controller.appendDigit(number)
                         }
                         .accessibilityIdentifier("pin_\(number)")
@@ -79,16 +105,16 @@ struct LockScreenView: View {
                 Button(action: controller.deleteDigit) {
                     Image(systemName: "delete.backward")
                         .font(.title2)
-                        .frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64)
+                        .frame(maxWidth: .infinity, minHeight: keyHeight, maxHeight: keyHeight)
                 }
                 .foregroundStyle(KlasTheme.onBackground)
                 .accessibilityIdentifier("pin_delete")
-                keypadButton(label: "0") {
+                keypadButton(label: "0", height: keyHeight) {
                     controller.appendDigit(0)
                 }
                 .accessibilityIdentifier("pin_0")
                 Color.clear
-                    .frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64)
+                    .frame(maxWidth: .infinity, minHeight: keyHeight, maxHeight: keyHeight)
             }
             Text("비밀번호를 잊어버린 경우 앱을 재설치해야 해요.")
                 .font(.caption)
@@ -100,13 +126,30 @@ struct LockScreenView: View {
         .accessibilityIdentifier("pin_keypad")
     }
 
-    private func keypadButton(label: String, action: @escaping () -> Void) -> some View {
+    private func keypadButton(label: String, height: CGFloat, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
                 .font(.title2)
-                .frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64)
+                .frame(maxWidth: .infinity, minHeight: height, maxHeight: height)
         }
         .foregroundStyle(KlasTheme.onBackground)
+    }
+
+    private func horizontalPadding(_ widthClass: AppWindowWidthClass) -> CGFloat {
+        switch widthClass {
+        case .compact: return 20
+        case .medium: return 40
+        case .expanded: return 64
+        }
+    }
+
+    private func keypadKeyHeight(availableHeight: CGFloat, twoPane: Bool) -> CGFloat {
+        let captionAndGaps: CGFloat = 56
+        let summaryReserve: CGFloat = twoPane ? 0 : 140
+        let rows: CGFloat = 4
+        let rowSpacing: CGFloat = 12
+        let leftover = availableHeight - captionAndGaps - summaryReserve - rowSpacing
+        return min(64, max(44, leftover / rows))
     }
 
     @ViewBuilder

--- a/iosApp/iosApp/LockScreenView.swift
+++ b/iosApp/iosApp/LockScreenView.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+struct LockScreenView: View {
+    @ObservedObject var controller: AppLockController
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer(minLength: 12)
+                lockSummary
+                Spacer(minLength: 12)
+                lockKeypad
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(KlasTheme.background.ignoresSafeArea())
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if controller.canCancel {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("취소") { controller.cancel() }
+                    }
+                }
+            }
+        }
+        .interactiveDismissDisabled()
+        .overlay(alignment: .bottom) { toast }
+        .onAppear { controller.promptUnlockBiometricIfNeeded() }
+        .accessibilityIdentifier("lock_screen")
+    }
+
+    private var lockSummary: some View {
+        VStack(spacing: 8) {
+            Text(controller.title)
+                .font(.title2.weight(.bold))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(KlasTheme.onBackground)
+            Text(controller.description)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(KlasTheme.onSurfaceVariant)
+            HStack(spacing: 16) {
+                ForEach(0..<LockScreenMetrics.pinLength, id: \.self) { index in
+                    Circle()
+                        .fill(
+                            index < controller.enteredDigits
+                                ? KlasTheme.primary
+                                : KlasTheme.outline.opacity(0.35)
+                        )
+                        .frame(width: 12, height: 12)
+                }
+            }
+            .padding(.top, 24)
+            .accessibilityIdentifier("pin_indicators")
+            if controller.biometricVisible {
+                Button("생체인식 사용") {
+                    controller.requestUnlockBiometric()
+                }
+                .padding(.top, 8)
+                .accessibilityIdentifier("biometric_button")
+            }
+        }
+    }
+
+    private var lockKeypad: some View {
+        VStack(spacing: 4) {
+            ForEach([[1, 2, 3], [4, 5, 6], [7, 8, 9]], id: \.first) { row in
+                HStack(spacing: 4) {
+                    ForEach(row, id: \.self) { number in
+                        keypadButton(label: String(number)) {
+                            controller.appendDigit(number)
+                        }
+                        .accessibilityIdentifier("pin_\(number)")
+                    }
+                }
+            }
+            HStack(spacing: 4) {
+                Button(action: controller.deleteDigit) {
+                    Image(systemName: "delete.backward")
+                        .font(.title2)
+                        .frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64)
+                }
+                .foregroundStyle(KlasTheme.onBackground)
+                .accessibilityIdentifier("pin_delete")
+                keypadButton(label: "0") {
+                    controller.appendDigit(0)
+                }
+                .accessibilityIdentifier("pin_0")
+                Color.clear
+                    .frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64)
+            }
+            Text("비밀번호를 잊어버린 경우 앱을 재설치해야 해요.")
+                .font(.caption)
+                .foregroundStyle(KlasTheme.outline)
+                .multilineTextAlignment(.center)
+                .padding(.top, 8)
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .accessibilityIdentifier("pin_keypad")
+    }
+
+    private func keypadButton(label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.title2)
+                .frame(maxWidth: .infinity, minHeight: 64, maxHeight: 64)
+        }
+        .foregroundStyle(KlasTheme.onBackground)
+    }
+
+    @ViewBuilder
+    private var toast: some View {
+        if let toast = controller.toastMessage {
+            Text(toast)
+                .font(.subheadline)
+                .foregroundStyle(KlasTheme.onSurface)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(KlasTheme.surfaceContainerHigh)
+                )
+                .padding(.bottom, 32)
+                .allowsHitTesting(false)
+                .accessibilityIdentifier("lock_toast")
+        }
+    }
+}

--- a/iosApp/iosApp/SettingsView.swift
+++ b/iosApp/iosApp/SettingsView.swift
@@ -5,12 +5,12 @@ import SwiftUI
 final class SettingsScreenModel: ObservableObject {
     let holder: WebViewHolder
     let coordinator: HomeCoordinator
+    let appLock: AppLockController
     private var host: SettingsHostAdapter
-    let lockSettingsJson: String
 
-    init(coordinator: HomeCoordinator) {
+    init(coordinator: HomeCoordinator, appLock: AppLockController) {
         self.coordinator = coordinator
-        self.lockSettingsJson = coordinator.homeRuntime.defaultAppLockSettingsJson()
+        self.appLock = appLock
         let host = SettingsHostAdapter()
         self.host = host
         self.holder = WebViewHolder.withLegacyBridge(
@@ -19,6 +19,7 @@ final class SettingsScreenModel: ObservableObject {
             synchronousHandler: IosSettingsLegacySynchronousBridgeCommandHandler(host: host)
         )
         host.model = self
+        host.store = appLock.store
         holder.load(KlasUrls.shared.SETTINGS)
     }
 
@@ -29,10 +30,80 @@ final class SettingsScreenModel: ObservableObject {
         holder.evaluate(IosWebCallbacks.shared.receiveYearHakgi(value: coordinator.yearHakgi))
         holder.evaluate(IosWebCallbacks.shared.receiveVersion(version: coordinator.appVersion))
     }
+
+    func currentLockSettingsJson() -> String {
+        appLock.store.currentSettings().toLegacyJson()
+    }
+
+    func setAppLockEnabled(enabled: Bool) {
+        if enabled {
+            appLock.presentPasswordSetup { [weak self] success in
+                self?.handleLockSetupResult(success: success, disabling: false)
+            }
+            return
+        }
+        if !appLock.store.hasPassword() {
+            notifyLockSettingsChanged()
+            return
+        }
+        appLock.presentVerifyToDisable { [weak self] success in
+            self?.handleLockSetupResult(success: success, disabling: true)
+        }
+    }
+
+    func setAppLockPassword() {
+        appLock.presentPasswordSetup { [weak self] success in
+            self?.handleLockSetupResult(success: success, disabling: false)
+        }
+    }
+
+    func setBiometricEnabled(enabled: Bool) {
+        if enabled {
+            if let message = IosBiometricAvailability.errorMessage() {
+                coordinator.showToast(message)
+                holder.evaluate(IosWebCallbacks.shared.biometricSettingChanged(enabled: false))
+                return
+            }
+            Task {
+                let result = await appLock.authenticateEnableBiometrics()
+                if result is PlatformActionResultSuccess {
+                    appLock.store.setBiometricEnabled(enabled: true)
+                    coordinator.showToast("생체인증이 활성화되었습니다.")
+                    holder.evaluate(IosWebCallbacks.shared.biometricSettingChanged(enabled: true))
+                } else {
+                    holder.evaluate(IosWebCallbacks.shared.biometricSettingChanged(enabled: false))
+                }
+            }
+        } else {
+            appLock.store.setBiometricEnabled(enabled: false)
+            coordinator.showToast("생체인증이 비활성화되었습니다.")
+            holder.evaluate(IosWebCallbacks.shared.biometricSettingChanged(enabled: false))
+        }
+    }
+
+    private func handleLockSetupResult(success: Bool, disabling: Bool) {
+        if !success {
+            notifyLockSettingsChanged()
+            coordinator.showToast("인증이 취소되었습니다.")
+            return
+        }
+        if disabling {
+            coordinator.showToast("앱 잠금이 비활성화되고 비밀번호가 초기화되었습니다.")
+        }
+        notifyLockSettingsChanged()
+    }
+
+    private func notifyLockSettingsChanged() {
+        holder.evaluate(
+            IosWebCallbacks.shared.appLockSettingChanged(settings: appLock.store.currentSettings())
+        )
+        holder.evaluate(IosWebCallbacks.shared.requestSettingsReload())
+    }
 }
 
 final class SettingsHostAdapter: SettingsBridgeHost {
     weak var model: SettingsScreenModel?
+    var store: IosAppLockStore?
 
     func completePageLoad() {
         Task { @MainActor in model?.completePageLoad() }
@@ -59,19 +130,19 @@ final class SettingsHostAdapter: SettingsBridgeHost {
     }
 
     func setAppLockEnabled(enabled: Bool) {
-        Task { @MainActor in model?.coordinator.presentUnavailable() }
+        Task { @MainActor in model?.setAppLockEnabled(enabled: enabled) }
     }
 
     func setAppLockPassword() {
-        Task { @MainActor in model?.coordinator.presentUnavailable() }
+        Task { @MainActor in model?.setAppLockPassword() }
     }
 
     func setBiometricEnabled(enabled: Bool) {
-        Task { @MainActor in model?.coordinator.presentUnavailable() }
+        Task { @MainActor in model?.setBiometricEnabled(enabled: enabled) }
     }
 
     func getAppLockSettings() -> String {
-        model?.lockSettingsJson
+        store?.currentSettings().toLegacyJson()
             ?? "{\"enabled\":false,\"biometric\":false,\"hasPassword\":false}"
     }
 }
@@ -80,8 +151,10 @@ struct SettingsView: View {
     @StateObject private var model: SettingsScreenModel
     @Environment(\.dismiss) private var dismiss
 
-    init(coordinator: HomeCoordinator) {
-        _model = StateObject(wrappedValue: SettingsScreenModel(coordinator: coordinator))
+    init(coordinator: HomeCoordinator, appLock: AppLockController) {
+        _model = StateObject(
+            wrappedValue: SettingsScreenModel(coordinator: coordinator, appLock: appLock)
+        )
     }
 
     var body: some View {

--- a/iosApp/iosApp/SettingsView.swift
+++ b/iosApp/iosApp/SettingsView.swift
@@ -20,6 +20,7 @@ final class SettingsScreenModel: ObservableObject {
         )
         host.model = self
         host.store = appLock.store
+        coordinator.attachSettingsWebView(holder)
         holder.load(KlasUrls.shared.SETTINGS)
     }
 

--- a/iosApp/iosApp/StartupRootView.swift
+++ b/iosApp/iosApp/StartupRootView.swift
@@ -2,7 +2,17 @@ import Shared
 import SwiftUI
 
 struct StartupRootView: View {
-    @StateObject private var controller = AuthSessionController()
+    @StateObject private var controller: AuthSessionController
+    @StateObject private var appLock: AppLockController
+    @Environment(\.scenePhase) private var scenePhase
+
+    init() {
+        let auth = AuthSessionController()
+        _controller = StateObject(wrappedValue: auth)
+        _appLock = StateObject(
+            wrappedValue: AppLockController(store: auth.authRuntime.dependencies.appLockStore)
+        )
+    }
 
     var body: some View {
         ZStack {
@@ -38,13 +48,32 @@ struct StartupRootView: View {
                 )
             }
         }
+        .environmentObject(appLock)
         .alert(blockedAlertTitle, isPresented: blockedAlertPresented) {
             blockedAlertButtons
         } message: {
             Text(blockedAlertMessage)
         }
         .accessibilityIdentifier(isBlocked ? "auth_alert" : "")
-        .onAppear { controller.start() }
+        .fullScreenCover(item: $appLock.mode) { _ in
+            LockScreenView(controller: appLock)
+                .preferredColorScheme(lockColorScheme)
+        }
+        .onAppear {
+            controller.start()
+            appLock.handleScenePhase(.active)
+        }
+        .onChange(of: scenePhase) { phase in
+            appLock.handleScenePhase(phase)
+        }
+    }
+
+    private var lockColorScheme: ColorScheme? {
+        switch controller.authRuntime.dependencies.stringPreference(key: "appTheme") {
+        case "dark": return .dark
+        case "light": return .light
+        default: return nil
+        }
     }
 
     private var isBlocked: Bool {

--- a/iosApp/iosAppTests/IosAppLockStoreTests.swift
+++ b/iosApp/iosAppTests/IosAppLockStoreTests.swift
@@ -78,7 +78,12 @@ final class AppLockControllerTests: XCTestCase {
     func testSetPinThenBackgroundRequestsUnlock() async {
         let env = LockTestEnvironment()
         defer { env.tearDown() }
-        let controller = AppLockController(store: env.store, canUseBiometrics: { false })
+        let controller = AppLockController(
+            store: env.store,
+            canUseBiometrics: { false },
+            isAppInBackground: { true },
+            backgroundLockDelayNanos: 0
+        )
         let finished = expectation(description: "set pin")
         var succeeded = false
 
@@ -94,10 +99,11 @@ final class AppLockControllerTests: XCTestCase {
         XCTAssertTrue(succeeded)
         XCTAssertTrue(env.store.isEnabled())
         XCTAssertTrue(env.store.verifyPassword(input: "123456"))
+        XCTAssertTrue(env.store.isUnlocked)
         XCTAssertNil(controller.mode)
 
-        env.store.isUnlocked = true
         controller.handleScenePhase(.background)
+        await waitUntil { !env.store.isUnlocked }
         XCTAssertFalse(env.store.isUnlocked)
         controller.handleScenePhase(.active)
         XCTAssertEqual(controller.mode, .unlock)
@@ -165,6 +171,116 @@ final class AppLockControllerTests: XCTestCase {
         XCTAssertFalse(LockScreenMetrics.useTwoPane(width: 834, height: 1194))
         XCTAssertTrue(LockScreenMetrics.useTwoPane(width: 1194, height: 834))
     }
+
+    func testEnableBiometricsDoesNotOpenUnlockScreen() async {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        env.store.savePassword(password: "123456")
+        env.store.setEnabled(enabled: true)
+        env.store.isUnlocked = true
+
+        let box = ControllerBox()
+        let controller = AppLockController(
+            store: env.store,
+            canUseBiometrics: { true },
+            isAppInBackground: { true },
+            authenticateBiometrics: { _, _ in
+                box.controller?.handleScenePhase(.background)
+                box.controller?.handleScenePhase(.active)
+                return PlatformActionResultSuccess()
+            }
+        )
+        box.controller = controller
+
+        let result = await controller.authenticateEnableBiometrics()
+        XCTAssertTrue(result is PlatformActionResultSuccess)
+        XCTAssertTrue(env.store.isUnlocked)
+        XCTAssertNil(controller.mode)
+    }
+
+    func testSetPinBiometricPromptDoesNotOpenUnlock() async {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        let box = ControllerBox()
+        let finished = expectation(description: "set pin")
+        let controller = AppLockController(
+            store: env.store,
+            canUseBiometrics: { true },
+            isAppInBackground: { true },
+            authenticateBiometrics: { _, _ in
+                box.controller?.handleScenePhase(.background)
+                box.controller?.handleScenePhase(.active)
+                return PlatformActionResultSuccess()
+            }
+        )
+        box.controller = controller
+        var succeeded = false
+        controller.presentPasswordSetup { success in
+            succeeded = success
+            finished.fulfill()
+        }
+        [1, 2, 3, 4, 5, 6].forEach(controller.appendDigit)
+        [1, 2, 3, 4, 5, 6].forEach(controller.appendDigit)
+
+        await fulfillment(of: [finished], timeout: 2)
+        XCTAssertTrue(succeeded)
+        XCTAssertTrue(env.store.isUnlocked)
+        XCTAssertTrue(env.store.isBiometricEnabled())
+        XCTAssertNil(controller.mode)
+    }
+
+    func testFaceIdInactiveDoesNotLockWhenAppStillForeground() {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        env.store.savePassword(password: "123456")
+        env.store.setEnabled(enabled: true)
+        env.store.isUnlocked = true
+        let controller = AppLockController(
+            store: env.store,
+            canUseBiometrics: { false },
+            isAppInBackground: { false }
+        )
+
+        controller.handleScenePhase(.background)
+        controller.handleScenePhase(.active)
+
+        XCTAssertTrue(env.store.isUnlocked)
+        XCTAssertNil(controller.mode)
+    }
+
+    func testQuickForegroundReturnDoesNotLock() async {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        env.store.savePassword(password: "123456")
+        env.store.setEnabled(enabled: true)
+        env.store.isUnlocked = true
+        let controller = AppLockController(
+            store: env.store,
+            canUseBiometrics: { false },
+            isAppInBackground: { true },
+            backgroundLockDelayNanos: 5_000_000_000
+        )
+
+        controller.handleScenePhase(.background)
+        controller.handleScenePhase(.active)
+
+        XCTAssertTrue(env.store.isUnlocked)
+        XCTAssertNil(controller.mode)
+    }
+
+    private func waitUntil(
+        timeout: TimeInterval = 1,
+        _ predicate: @escaping () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !predicate(), Date() < deadline {
+            await Task.yield()
+        }
+    }
+}
+
+private final class ControllerBox {
+    var controller: AppLockController?
 }
 
 private final class LockTestEnvironment {

--- a/iosApp/iosAppTests/IosAppLockStoreTests.swift
+++ b/iosApp/iosAppTests/IosAppLockStoreTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import Shared
+import XCTest
+@testable import kw_klas_plus
+
+final class IosAppLockStoreTests: XCTestCase {
+    func testSaveVerifyAndDisableClearsSecretsFromUserDefaults() {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+
+        XCTAssertFalse(env.store.isEnabled())
+        XCTAssertFalse(env.store.hasPassword())
+        XCTAssertEqual(
+            env.store.currentSettings().toLegacyJson(),
+            "{\"enabled\":false,\"biometric\":false,\"hasPassword\":false}"
+        )
+
+        env.store.savePassword(password: "123456")
+        env.store.setEnabled(enabled: true)
+        env.store.setBiometricEnabled(enabled: true)
+
+        XCTAssertTrue(env.store.isEnabled())
+        XCTAssertTrue(env.store.hasPassword())
+        XCTAssertTrue(env.store.verifyPassword(input: "123456"))
+        XCTAssertFalse(env.store.verifyPassword(input: "000000"))
+        XCTAssertEqual(
+            env.store.currentSettings().toLegacyJson(),
+            "{\"enabled\":true,\"biometric\":true,\"hasPassword\":true}"
+        )
+        XCTAssertTrue(env.defaults.bool(forKey: "a_l_e"))
+        XCTAssertTrue(env.defaults.bool(forKey: "b_m_e"))
+        assertUserDefaults(env.defaults, doesNotContain: "123456")
+
+        env.store.setEnabled(enabled: false)
+
+        XCTAssertFalse(env.store.isEnabled())
+        XCTAssertFalse(env.store.hasPassword())
+        XCTAssertFalse(env.store.isBiometricEnabled())
+        XCTAssertFalse(env.store.verifyPassword(input: "123456"))
+        XCTAssertFalse(env.defaults.bool(forKey: "a_l_e"))
+        XCTAssertFalse(env.defaults.bool(forKey: "b_m_e"))
+        XCTAssertNil(env.defaults.string(forKey: "p_w_h"))
+        XCTAssertNil(env.defaults.string(forKey: "p_w_s"))
+    }
+
+    func testHomeRuntimeJsonReadsLiveStore() {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        env.store.savePassword(password: "654321")
+        env.store.setEnabled(enabled: true)
+
+        let runtime = IosHomeRuntime.companion.create(dependencies: env.dependencies)
+        XCTAssertEqual(
+            runtime.defaultAppLockSettingsJson(),
+            "{\"enabled\":true,\"biometric\":false,\"hasPassword\":true}"
+        )
+    }
+
+    private func assertUserDefaults(
+        _ defaults: UserDefaults,
+        doesNotContain secret: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for (key, value) in defaults.dictionaryRepresentation() {
+            XCTAssertFalse(
+                String(describing: value).contains(secret),
+                "UserDefaults[\(key)] leaked secret",
+                file: file,
+                line: line
+            )
+        }
+    }
+}
+
+@MainActor
+final class AppLockControllerTests: XCTestCase {
+    func testSetPinThenBackgroundRequestsUnlock() async {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        let controller = AppLockController(store: env.store, canUseBiometrics: { false })
+        let finished = expectation(description: "set pin")
+        var succeeded = false
+
+        controller.presentPasswordSetup { success in
+            succeeded = success
+            finished.fulfill()
+        }
+        XCTAssertEqual(controller.mode, .set)
+        [1, 2, 3, 4, 5, 6].forEach(controller.appendDigit)
+        [1, 2, 3, 4, 5, 6].forEach(controller.appendDigit)
+
+        await fulfillment(of: [finished], timeout: 2)
+        XCTAssertTrue(succeeded)
+        XCTAssertTrue(env.store.isEnabled())
+        XCTAssertTrue(env.store.verifyPassword(input: "123456"))
+        XCTAssertNil(controller.mode)
+
+        env.store.isUnlocked = true
+        controller.handleScenePhase(.background)
+        XCTAssertFalse(env.store.isUnlocked)
+        controller.handleScenePhase(.active)
+        XCTAssertEqual(controller.mode, .unlock)
+    }
+
+    func testCancelRestoreDoesNotEnableLock() {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        let controller = AppLockController(store: env.store, canUseBiometrics: { false })
+        var succeeded: Bool?
+        controller.presentPasswordSetup { success in
+            succeeded = success
+        }
+        controller.cancel()
+        XCTAssertEqual(succeeded, false)
+        XCTAssertFalse(env.store.isEnabled())
+        XCTAssertNil(controller.mode)
+        XCTAssertFalse(env.store.hasPassword())
+    }
+
+    func testVerifyDisableClearsPassword() async {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        env.store.savePassword(password: "123456")
+        env.store.setEnabled(enabled: true)
+        let controller = AppLockController(store: env.store, canUseBiometrics: { false })
+        let finished = expectation(description: "disable")
+        var succeeded = false
+
+        controller.presentVerifyToDisable { success in
+            succeeded = success
+            finished.fulfill()
+        }
+        [1, 2, 3, 4, 5, 6].forEach(controller.appendDigit)
+
+        await fulfillment(of: [finished], timeout: 2)
+        XCTAssertTrue(succeeded)
+        XCTAssertFalse(env.store.isEnabled())
+        XCTAssertFalse(env.store.hasPassword())
+    }
+}
+
+private final class LockTestEnvironment {
+    let suite: String
+    let defaults: UserDefaults
+    let keychain: IosKeychainSecureStore
+    let store: IosAppLockStore
+    let dependencies: IosSharedDependencies
+
+    init() {
+        suite = "com.icecream.kwklasplus.test.applock.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        keychain = IosKeychainSecureStore(
+            service: "com.icecream.kwklasplus.test.applock.keychain.\(UUID().uuidString)"
+        )
+        dependencies = IosSharedDependencies.companion.create(
+            defaults: defaults,
+            secureStore: keychain,
+            cookieStore: nil
+        )
+        store = dependencies.appLockStore
+    }
+
+    func tearDown() {
+        store.setEnabled(enabled: false)
+        defaults.removePersistentDomain(forName: suite)
+    }
+}

--- a/iosApp/iosAppTests/IosAppLockStoreTests.swift
+++ b/iosApp/iosAppTests/IosAppLockStoreTests.swift
@@ -138,6 +138,25 @@ final class AppLockControllerTests: XCTestCase {
         XCTAssertFalse(env.store.isEnabled())
         XCTAssertFalse(env.store.hasPassword())
     }
+
+    func testSettingsHostReadsStoreJson() {
+        let env = LockTestEnvironment()
+        defer { env.tearDown() }
+        env.store.savePassword(password: "112233")
+        env.store.setEnabled(enabled: true)
+        env.store.setBiometricEnabled(enabled: true)
+
+        let authRuntime = IosAuthRuntime.companion.create(dependencies: env.dependencies)
+        let coordinator = HomeCoordinator(authRuntime: authRuntime, onLogout: {})
+        let appLock = AppLockController(store: env.store, canUseBiometrics: { false })
+        let model = SettingsScreenModel(coordinator: coordinator, appLock: appLock)
+
+        XCTAssertEqual(
+            model.currentLockSettingsJson(),
+            "{\"enabled\":true,\"biometric\":true,\"hasPassword\":true}"
+        )
+        model.holder.dispose()
+    }
 }
 
 private final class LockTestEnvironment {

--- a/iosApp/iosAppTests/IosAppLockStoreTests.swift
+++ b/iosApp/iosAppTests/IosAppLockStoreTests.swift
@@ -157,6 +157,14 @@ final class AppLockControllerTests: XCTestCase {
         )
         model.holder.dispose()
     }
+
+    func testLandscapeUsesTwoPaneLikeAndroid() {
+        XCTAssertFalse(LockScreenMetrics.useTwoPane(width: 393, height: 852))
+        XCTAssertTrue(LockScreenMetrics.useTwoPane(width: 852, height: 393))
+        XCTAssertTrue(LockScreenMetrics.useTwoPane(width: 932, height: 430))
+        XCTAssertFalse(LockScreenMetrics.useTwoPane(width: 834, height: 1194))
+        XCTAssertTrue(LockScreenMetrics.useTwoPane(width: 1194, height: 834))
+    }
 }
 
 private final class LockTestEnvironment {

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/lock/AppLockSettings.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/lock/AppLockSettings.kt
@@ -33,4 +33,8 @@ class AppLockPolicy {
         AppLockEvent.AuthenticationFailed -> state.copy(unlocked = false)
         AppLockEvent.LockDisabled -> AppLockState(enabled = false, unlocked = true)
     }
+
+    companion object {
+        const val BACKGROUND_LOCK_DELAY_MS = 700L
+    }
 }

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/lock/AppLockPolicyTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/lock/AppLockPolicyTest.kt
@@ -15,6 +15,11 @@ class AppLockPolicyTest {
     }
 
     @Test
+    fun backgroundLockDelayMatchesProcessLifecycleOwner() {
+        assertEquals(700L, AppLockPolicy.BACKGROUND_LOCK_DELAY_MS)
+    }
+
+    @Test
     fun backgroundLocksEnabledApp() {
         val state = AppLockPolicy().reduce(
             AppLockState(enabled = true, unlocked = true),

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosAuthRuntime.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosAuthRuntime.kt
@@ -88,5 +88,8 @@ class IosAuthRuntime(
 
         fun create(defaults: NSUserDefaults): IosAuthRuntime =
             IosAuthRuntime(IosSharedDependencies(defaults = defaults))
+
+        fun create(dependencies: IosSharedDependencies): IosAuthRuntime =
+            IosAuthRuntime(dependencies)
     }
 }

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosHomeRuntime.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosHomeRuntime.kt
@@ -10,7 +10,6 @@ import com.icecream.kwklasplus.core.academic.DeadlinesWebCodec
 import com.icecream.kwklasplus.core.academic.TimetableResult
 import com.icecream.kwklasplus.core.academic.TimetableWebCodec
 import com.icecream.kwklasplus.core.legacy.LegacyPreferenceKeys
-import com.icecream.kwklasplus.core.lock.AppLockSettings
 import com.icecream.kwklasplus.core.network.KlasUserAgent
 import com.icecream.kwklasplus.core.security.SecretValue
 import com.icecream.kwklasplus.core.session.SessionResult
@@ -71,11 +70,8 @@ class IosHomeRuntime(
     fun currentYearHakgiListJoined(): String =
         dependencies.stringPreference(LegacyPreferenceKeys.YEAR_HAKGI_LIST).orEmpty()
 
-    fun defaultAppLockSettingsJson(): String = AppLockSettings(
-        enabled = false,
-        biometricEnabled = false,
-        hasPassword = false,
-    ).toLegacyJson()
+    fun defaultAppLockSettingsJson(): String =
+        dependencies.appLockStore.currentSettings().toLegacyJson()
 
     fun yearHakgiButtonText(value: String): String = AcademicTermDisplay.buttonText(value)
 

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
@@ -11,6 +11,9 @@ import com.icecream.kwklasplus.core.auth.LoginUseCase
 import com.icecream.kwklasplus.core.auth.PrepareCredentialUseCase
 import com.icecream.kwklasplus.core.auth.WebAuthDriver
 import com.icecream.kwklasplus.core.legacy.LegacyPreferenceKeys
+import com.icecream.kwklasplus.core.lock.IosAppLockCredentialCodec
+import com.icecream.kwklasplus.core.lock.IosAppLockSecretStore
+import com.icecream.kwklasplus.core.lock.IosAppLockStore
 import com.icecream.kwklasplus.core.network.KlasSessionHttpClient
 import com.icecream.kwklasplus.core.network.createIosKlasHttpClient
 import com.icecream.kwklasplus.core.platform.IosUserDefaultsPreferencesStore
@@ -68,8 +71,20 @@ class IosSharedDependencies(
         defaults.synchronize()
     }
 
+    private val iosKeychainStore: IosKeychainSecureStore by lazy {
+        (secureStoreOverride as? IosKeychainSecureStore) ?: IosKeychainSecureStore()
+    }
+
     val secureStore: SecureStore by lazy {
-        secureStoreOverride ?: IosKeychainSecureStore()
+        secureStoreOverride ?: iosKeychainStore
+    }
+
+    val appLockCredentialCodec by lazy { IosAppLockCredentialCodec() }
+
+    val appLockSecretStore by lazy { IosAppLockSecretStore(iosKeychainStore) }
+
+    val appLockStore by lazy {
+        IosAppLockStore(defaults, appLockSecretStore, appLockCredentialCodec)
     }
 
     val credentialStore: CredentialStore by lazy {
@@ -111,5 +126,17 @@ class IosSharedDependencies(
         defaults.removeObjectForKey(LegacyPreferenceKeys.YEAR_HAKGI)
         defaults.removeObjectForKey(LegacyPreferenceKeys.YEAR_HAKGI_LIST)
         defaults.synchronize()
+    }
+
+    companion object {
+        fun create(
+            defaults: NSUserDefaults,
+            secureStore: SecureStore? = null,
+            cookieStore: IosWebCookieStore? = null,
+        ): IosSharedDependencies = IosSharedDependencies(
+            defaults = defaults,
+            secureStoreOverride = secureStore,
+            cookieStoreOverride = cookieStore,
+        )
     }
 }

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockCredentialCodec.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockCredentialCodec.kt
@@ -1,0 +1,44 @@
+package com.icecream.kwklasplus.core.lock
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.usePinned
+import platform.CoreCrypto.CC_SHA256
+import platform.CoreCrypto.CC_SHA256_DIGEST_LENGTH
+import platform.Security.SecRandomCopyBytes
+import platform.Security.errSecSuccess
+import platform.Security.kSecRandomDefault
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalEncodingApi::class)
+class IosAppLockCredentialCodec : AppLockCredentialCodec {
+    override fun generateSalt(): String {
+        val salt = ByteArray(SALT_SIZE_BYTES)
+        val status = salt.usePinned { pinned ->
+            SecRandomCopyBytes(kSecRandomDefault, SALT_SIZE_BYTES.convert(), pinned.addressOf(0))
+        }
+        check(status == errSecSuccess) { "Failed to generate app lock salt: status=$status" }
+        return Base64.encode(salt)
+    }
+
+    override fun hash(password: String, salt: String): String {
+        val input = (password + salt).encodeToByteArray()
+        val digest = UByteArray(CC_SHA256_DIGEST_LENGTH)
+        input.usePinned { inputPinned ->
+            digest.usePinned { digestPinned ->
+                CC_SHA256(
+                    inputPinned.addressOf(0),
+                    input.size.convert(),
+                    digestPinned.addressOf(0),
+                )
+            }
+        }
+        return Base64.encode(digest.asByteArray())
+    }
+
+    private companion object {
+        const val SALT_SIZE_BYTES = 16
+    }
+}

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockSecretStore.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockSecretStore.kt
@@ -1,0 +1,42 @@
+package com.icecream.kwklasplus.core.lock
+
+import com.icecream.kwklasplus.core.platform.SecureKey
+import com.icecream.kwklasplus.core.security.IosKeychainSecureStore
+import com.icecream.kwklasplus.core.security.SecretValue
+
+class IosAppLockSecretStore(
+    private val secureStore: IosKeychainSecureStore,
+) {
+    fun readHash(): String? = secureStore.readNow(SecureKey.APP_LOCK_HASH)?.reveal()
+
+    fun readSalt(): String? = secureStore.readNow(SecureKey.APP_LOCK_SALT)?.reveal()
+
+    fun write(hash: String, salt: String) {
+        val previousHash = secureStore.readNow(SecureKey.APP_LOCK_HASH)
+        val previousSalt = secureStore.readNow(SecureKey.APP_LOCK_SALT)
+        secureStore.writeNow(SecureKey.APP_LOCK_HASH, SecretValue.of(hash))
+        try {
+            secureStore.writeNow(SecureKey.APP_LOCK_SALT, SecretValue.of(salt))
+            check(readHash() == hash && readSalt() == salt)
+        } catch (cause: Throwable) {
+            restore(SecureKey.APP_LOCK_HASH, previousHash)
+            restore(SecureKey.APP_LOCK_SALT, previousSalt)
+            throw cause
+        }
+    }
+
+    fun clear() {
+        var failure: Throwable? = null
+        runCatching { secureStore.removeNow(SecureKey.APP_LOCK_HASH) }
+            .onFailure { failure = it }
+        runCatching { secureStore.removeNow(SecureKey.APP_LOCK_SALT) }
+            .onFailure { if (failure == null) failure = it }
+        failure?.let { throw it }
+    }
+
+    private fun restore(key: SecureKey, value: SecretValue?) {
+        runCatching {
+            if (value == null) secureStore.removeNow(key) else secureStore.writeNow(key, value)
+        }
+    }
+}

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockStore.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockStore.kt
@@ -1,0 +1,61 @@
+package com.icecream.kwklasplus.core.lock
+
+import platform.Foundation.NSUserDefaults
+
+class IosAppLockStore(
+    private val defaults: NSUserDefaults,
+    private val secretStore: IosAppLockSecretStore,
+    private val codec: AppLockCredentialCodec,
+) {
+    var isUnlocked: Boolean = false
+
+    fun isEnabled(): Boolean = defaults.boolForKey(ENABLED_KEY)
+
+    fun isBiometricEnabled(): Boolean = defaults.boolForKey(BIOMETRIC_KEY)
+
+    fun hasPassword(): Boolean = secretStore.readHash() != null
+
+    fun verifyPassword(input: String): Boolean {
+        val savedHash = secretStore.readHash() ?: return false
+        val savedSalt = secretStore.readSalt() ?: return false
+        return codec.verify(input, savedHash, savedSalt)
+    }
+
+    fun savePassword(password: String) {
+        val salt = codec.generateSalt()
+        val hash = codec.hash(password, salt)
+        secretStore.write(hash, salt)
+    }
+
+    fun setEnabled(enabled: Boolean) {
+        defaults.setBool(enabled, ENABLED_KEY)
+        defaults.synchronize()
+        if (!enabled) {
+            secretStore.clear()
+            defaults.setBool(false, BIOMETRIC_KEY)
+            defaults.synchronize()
+            isUnlocked = false
+        }
+    }
+
+    fun setBiometricEnabled(enabled: Boolean) {
+        defaults.setBool(enabled, BIOMETRIC_KEY)
+        defaults.synchronize()
+    }
+
+    fun currentSettings(): AppLockSettings = AppLockSettings(
+        enabled = isEnabled(),
+        biometricEnabled = isBiometricEnabled(),
+        hasPassword = hasPassword(),
+    )
+
+    fun currentState(): AppLockState = AppLockState(
+        enabled = isEnabled(),
+        unlocked = isUnlocked,
+    )
+
+    private companion object {
+        const val ENABLED_KEY = "a_l_e"
+        const val BIOMETRIC_KEY = "b_m_e"
+    }
+}

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/security/IosKeychainSecureStore.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/security/IosKeychainSecureStore.kt
@@ -46,7 +46,9 @@ import platform.Security.kSecValueData
 class IosKeychainSecureStore(
     private val service: String = DEFAULT_SERVICE,
 ) : SecureStore {
-    override suspend fun read(key: SecureKey): SecretValue? {
+    override suspend fun read(key: SecureKey): SecretValue? = readNow(key)
+
+    fun readNow(key: SecureKey): SecretValue? {
         val query = mutableDictionary(capacity = 5) {
             addCf(kSecClass, kSecClassGenericPassword)
             addBridged(kSecAttrService, service)
@@ -71,7 +73,9 @@ class IosKeychainSecureStore(
         }
     }
 
-    override suspend fun write(key: SecureKey, value: SecretValue) {
+    override suspend fun write(key: SecureKey, value: SecretValue) = writeNow(key, value)
+
+    fun writeNow(key: SecureKey, value: SecretValue) {
         val data = NSString.create(string = value.reveal())
             .dataUsingEncoding(NSUTF8StringEncoding)
             ?: error("Keychain write encoding failed for ${key.name}")
@@ -99,7 +103,9 @@ class IosKeychainSecureStore(
         }
     }
 
-    override suspend fun remove(key: SecureKey) {
+    override suspend fun remove(key: SecureKey) = removeNow(key)
+
+    fun removeNow(key: SecureKey) {
         val status = SecItemDelete(baseQuery(key))
         check(status == errSecSuccess || status == errSecItemNotFound) {
             "Keychain remove failed for ${key.name}: status=$status"

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/web/IosWebCallbacks.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/web/IosWebCallbacks.kt
@@ -68,4 +68,19 @@ object IosWebCallbacks {
 
     fun appLockSettingChanged(settings: AppLockSettings): WebScript =
         LegacyWebScripts.appLockSettingChanged(settings)
+
+    fun appLockSettingChanged(enabled: Boolean): WebScript =
+        LegacyWebScripts.call(
+            LegacyWebCallback.APP_LOCK_SETTING_CHANGED,
+            JavaScriptArgument.BooleanValue(enabled),
+        )
+
+    fun biometricSettingChanged(enabled: Boolean): WebScript =
+        LegacyWebScripts.call(
+            LegacyWebCallback.BIOMETRIC_SETTING_CHANGED,
+            JavaScriptArgument.BooleanValue(enabled),
+        )
+
+    fun requestSettingsReload(): WebScript =
+        WebScript("document.dispatchEvent(new Event('visibilitychange'));")
 }

--- a/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockCredentialCodecTest.kt
+++ b/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/lock/IosAppLockCredentialCodecTest.kt
@@ -1,0 +1,28 @@
+package com.icecream.kwklasplus.core.lock
+
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class IosAppLockCredentialCodecTest {
+    private val codec = IosAppLockCredentialCodec()
+
+    @Test
+    fun hashMatchesReleasedSha256PasswordSaltFormat() {
+        assertEquals(
+            "eje4XIkY6sGakInA+loqtNzj+QUo3N7sEIsj3fNge5k=",
+            codec.hash("password", "salt"),
+        )
+        assertTrue(codec.verify("password", codec.hash("password", "salt"), "salt"))
+        assertFalse(codec.verify("wrong", codec.hash("password", "salt"), "salt"))
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    @Test
+    fun generatedSaltKeepsLegacySixteenByteBase64Format() {
+        assertEquals(16, Base64.decode(codec.generateSalt()).size)
+    }
+}

--- a/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/web/IosWebCallbacksTest.kt
+++ b/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/web/IosWebCallbacksTest.kt
@@ -2,6 +2,7 @@ package com.icecream.kwklasplus.core.web
 
 import com.icecream.kwklasplus.core.academic.AcademicTermDisplay
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class IosWebCallbacksTest {
@@ -18,6 +19,18 @@ class IosWebCallbacksTest {
             IosWebCallbacks.updateYearHakgiButtonText(AcademicTermDisplay.buttonText("2026,1"))
                 .reveal()
                 .contains("년도"),
+        )
+        assertEquals(
+            "window.onAppLockSettingChanged(false);",
+            IosWebCallbacks.appLockSettingChanged(false).reveal(),
+        )
+        assertEquals(
+            "window.onBiometricSettingChanged(true);",
+            IosWebCallbacks.biometricSettingChanged(true).reveal(),
+        )
+        assertEquals(
+            "document.dispatchEvent(new Event('visibilitychange'));",
+            IosWebCallbacks.requestSettingsReload().reveal(),
         )
     }
 }


### PR DESCRIPTION
## Summary

- iOS에 Android와 같은 앱 잠금 경로를 붙입니다. PIN hash/salt는 Keychain, 사용/생체 플래그는 UserDefaults `a_l_e`/`b_m_e`에 두고 평문 PIN은 저장하지 않습니다.
- SwiftUI PIN 화면이 SET/CHANGE/VERIFY/UNLOCK을 처리하고, `scenePhase`는 공통 `AppLockPolicy`로 백그라운드 복귀 시 잠금 화면을 띄웁니다. 생체인증은 `LocalAuthentication`(Face ID/Touch ID)입니다.
- 설정 WebView의 앱 잠금 토글·비밀번호·생체 옵션이 실제 저장소를 읽고, 취소 시 `visibilitychange`로 웹 토글을 되돌립니다. 
- 설정화면에서 학기를 변경 시 웹뷰에 반영이 안되는 문제가 있어 같이 수정했습니다.
- 백그라운드 잠금 시점은 Android `ProcessLifecycleOwner`와 맞춥니다. Android는 ON_STOP을 700ms 미루므로, 홈으로 나갔다 그 안에 돌아오면 잠금 화면이 뜨지 않습니다. iOS도 같은 700ms 뒤에만 잠그고, Face ID/inactive는 실제 백그라운드로 보지 않습니다.


## Test Plan

- `./gradlew :shared:iosSimulatorArm64Test --tests 'com.icecream.kwklasplus.core.lock.IosAppLockCredentialCodecTest' --tests 'com.icecream.kwklasplus.core.web.IosWebCallbacksTest'`
- `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test -only-testing:iosAppTests/IosAppLockStoreTests -only-testing:iosAppTests/AppLockControllerTests`
- 설정에서 앱 잠금 ON → PIN 두 번 입력 → 토글이 ON으로 유지되는지
- PIN 설정 중 취소 → 토글이 OFF로 돌아가는지
- 앱 잠금 OFF → 기존 PIN 확인 후 토글 OFF, Keychain hash/salt 삭제
- 비밀번호 변경: 현재 PIN → 새 PIN 두 번
- 백그라운드 복귀 시 UNLOCK 화면, 맞는 PIN이면 해제
- 설정에서 연도/학기 변경 후 설정 WebView에도 반영되는지

iOS

https://github.com/user-attachments/assets/b4603372-8964-4d78-a82b-b32960e8351e

iPad

https://github.com/user-attachments/assets/c853b145-179d-4229-9b3d-1fb8f7c56bef

