### PR TITLE
fix: 학번 Prefill 테스트가 앱 Keychain을 읽지 않도록 격리

### DIFF
--- a/iosApp/iosAppTests/AuthSessionControllerTests.swift
+++ b/iosApp/iosAppTests/AuthSessionControllerTests.swift
@@ -52,14 +52,19 @@ final class AuthSessionControllerTests: XCTestCase {
         defaults.removePersistentDomain(forName: suite)
         defaults.set("2020123456", forKey: "kwID")
         defer { defaults.removePersistentDomain(forName: suite) }
+
+        let keychain = IosKeychainSecureStore(
+            service: "com.icecream.kwklasplus.test.auth.prefill.keychain.\(UUID().uuidString)"
+        )
         let controller = AuthSessionController(
-            authRuntime: IosAuthRuntime.companion.create(defaults: defaults),
+            authRuntime: IosAuthRuntime.companion.createForTests(defaults: defaults, secureStore: keychain),
             networkPath: FakeNetworkPathChecker(satisfied: true)
         )
 
         controller.start()
         await waitUntil { controller.phase == .needsCredentials }
 
+        XCTAssertEqual(controller.phase, .needsCredentials)
         XCTAssertEqual(controller.loginState.studentId, "2020123456")
         XCTAssertEqual(controller.loginState.password, "")
         XCTAssertFalse(controller.loginState.onboardingVisible)
@@ -106,13 +111,16 @@ final class AuthSessionControllerTests: XCTestCase {
 
     private func waitUntil(
         timeout: TimeInterval = 3,
-        predicate: @escaping () -> Bool
+        predicate: @escaping () -> Bool,
+        file: StaticString = #filePath,
+        line: UInt = #line
     ) async {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if predicate() { return }
             try? await Task.sleep(nanoseconds: 20_000_000)
         }
+        XCTAssertTrue(predicate(), "waitUntil timed out", file: file, line: line)
     }
 }
 

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosAuthRuntime.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosAuthRuntime.kt
@@ -5,6 +5,7 @@ import com.icecream.kwklasplus.core.auth.LoginResult
 import com.icecream.kwklasplus.core.auth.PlainPassword
 import com.icecream.kwklasplus.core.auth.StoredCredential
 import com.icecream.kwklasplus.core.auth.WebAuthDriver
+import com.icecream.kwklasplus.core.platform.SecureStore
 import com.icecream.kwklasplus.core.security.SecretValue
 import com.icecream.kwklasplus.core.session.SessionResult
 import kotlinx.coroutines.CoroutineScope
@@ -88,5 +89,11 @@ class IosAuthRuntime(
 
         fun create(defaults: NSUserDefaults): IosAuthRuntime =
             IosAuthRuntime(IosSharedDependencies(defaults = defaults))
+
+        // NOTE: For tests that inject SecureStore. App code should use createDefault() or create(defaults:).
+        fun createForTests(defaults: NSUserDefaults, secureStore: SecureStore): IosAuthRuntime =
+            IosAuthRuntime(
+                IosSharedDependencies(defaults = defaults, secureStoreOverride = secureStore),
+            )
     }
 }


### PR DESCRIPTION
related #18

`testStartPrefillsRetainedAccountIdWithoutPassword`는 “학번만 남고 비밀번호는 없다”는 픽스처인데, UserDefaults suite만 격리하고 SecureStore는 앱 기본 Keychain(`com.icecream.kwklasplus.secure`)을 그대로 썼습니다.

`IosCredentialStore.load()`는 `kwID`와 Keychain의 `ENCRYPTED_KLAS_PASSWORD`를 같이 읽습니다. 시뮬레이터에 로그인 흔적이 있으면 `load()`가 성공해 자동 로그인 경로로 가고, 학번 프리필(`loadAccountIdForLogin`)은 호출되지 않습니다. 그 결과 테스트는 로그인 화면에 도달하지 못한 채로 `studentId`가 비어 있다고 실패합니다. `waitUntil`은 타임아웃이 나도 실패하지 않아 원인이 가려졌습니다.

<img width="743" height="309" alt="Test Failed" src="https://github.com/user-attachments/assets/d113f26d-1fe8-4e29-b528-4e9162ce2624" />

테스트에 UUID 서비스의 빈 `IosKeychainSecureStore`를 넣고, Swift에서 주입할 수 있게 `IosAuthRuntime.createForTests(defaults, secureStore)`를 추가해 앱 Keychain을 읽지 않도록 격리했습니다.