### PR TITLE
feat: QR 출석 기능 (M7-002)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -15,7 +15,7 @@
 | M4 Android Web/Compose | 진행 중(7/8)   | Android 화면 전환 완료. legacy 자산 정리만 남음        |
 | M5 Android 기능 패리티      | **완료(7/7)** | QR·잠금·PIP·위젯·파일·테마 및 전체 Android 회귀 통과     |
 | M6 iOS 기본 경로           | 진행 중(9/11)  | M6-010 다운로드·외부 이동 완료. 파일 업로드 실계정 검증 남음. 다음: M6-011 UI 환경 |
-| M7 iOS 플랫폼 기능          | 진행 중(1/7)    | M7-001 앱 잠금 완료. 다음: M7-002 QR 출석 |
+| M7 iOS 플랫폼 기능          | 진행 중(2/7)    | M7-002 QR 출석 완료. 다음: M7-003 온라인 강의 player·PIP |
 
 ### M1 — 기존 계약 고정
 
@@ -150,8 +150,11 @@
     - `./gradlew :shared:iosSimulatorArm64Test --tests 'com.icecream.kwklasplus.core.lock.IosAppLockCredentialCodecTest' --tests 'com.icecream.kwklasplus.core.web.IosWebCallbacksTest'`
     - `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test -only-testing:iosAppTests/IosAppLockStoreTests -only-testing:iosAppTests/AppLockControllerTests`
   - 남은 일: Face ID 활성화·UNLOCK은 실기기 검증
-- [ ] **M7-002 (P0, L)** QR 출석 스캐너
+- [x] **M7-002 (P0, L)** QR 출석 스캐너
   - Depends on: M6-009
+  - 구현: Home `qrCheckIn` / Lecture `openQRScan` → `AttendanceRepository` + VisionKit `DataScannerViewController`
+  - 검증: `iosAppTests/QrAttendanceTests`. 
+  - 남은일: 실기기로 카메라가 뜨는 것까지는 검증했으나, 실제 강의 QR은 테스트해보지 못함.
 - [ ] **M7-003 (P0, M)** iOS 온라인 강의 player·PIP 방식 결정
   - Depends on: M6-009
   - 작업: KLAS 강의 URL/진도 추출, WKWebView media와 AVPlayer 중 재생 방식, `AVPictureInPictureController` 연결 가능성을 비교

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -33,7 +33,7 @@
 | F-016 | 일반 링크 | typed navigation + Android adapter | iOS navigation adapter | P1 | Parity | iOS M6-009: `AppRouteFactory` + Link host. `openPage`는 `www.kw.ac.kr` 공지처럼 비앱 https도 Link WKWebView에 로드한다. 이후 같은 화면의 http(s)는 인앱에 남긴다(Android LinkView의 이후 비신뢰 클릭 Chrome 이동과 승인 차이). `openExternalPage`만 Safari |
 | F-017 | 온라인 강의 재생 | Android player/PIP host | iOS player host | P0 | Parity | 재생·seek·speed·진도 포함 |
 | F-018 | PIP | Android native | AVKit/WK media | P1 | Parity | remote action·상태 복구 포함 |
-| F-019 | QR 출석 | Android scanner port | AVFoundation/VisionKit port | P0 | Parity | 성공·실패·취소·중복 실행 포함 |
+| F-019 | QR 출석 | Android scanner port | AVFoundation/VisionKit port | P0 | Parity | iOS: VisionKit `DataScannerViewController`, Home `qrCheckIn`·Lecture `openQRScan`, 성공·실패·취소·중복 실행 (`QrAttendanceTests`). |
 | F-020 | 도서관 QR 조회 | 공통 API + Android UI | 공통 API + iOS UI | P1 | Parity | 캐시·밝기·IME·갱신 포함 |
 | F-021 | 홈 화면 도서관 위젯 | AppWidgetProvider | WidgetKit extension | P1 | Parity | 잠금·만료·테마 포함 |
 | F-022 | 앱 잠금 PIN | 공통 policy + Android lifecycle | 공통 policy + iOS scene phase | P0 | Parity | iOS PIN SET/CHANGE/VERIFY/UNLOCK, Settings `getAppLockSettings`/`onAppLockSettingChanged`. hash/salt는 Keychain, 플래그는 UserDefaults `a_l_e`/`b_m_e`. 위젯 예외는 M7-006. (`IosAppLockStoreTests`, `AppLockControllerTests`) |

--- a/iosApp/iosApp/HomeCoordinator.swift
+++ b/iosApp/iosApp/HomeCoordinator.swift
@@ -28,6 +28,13 @@ enum HomeBootstrapPhase: Equatable {
     case failed(String)
 }
 
+enum QrAttendancePhase: Equatable {
+    case idle
+    case preparing
+    case authenticating
+    case result(title: String, message: String)
+}
+
 @MainActor
 final class HomeCoordinator: ObservableObject {
     @Published var path = NavigationPath()
@@ -44,6 +51,8 @@ final class HomeCoordinator: ObservableObject {
     @Published var datePickerIsStart = true
     @Published var showLogoutConfirm = false
     @Published var theme = "system"
+    @Published var qrPhase: QrAttendancePhase = .idle
+    @Published var isPresentingQrScanner = false
 
     let homeRuntime: IosHomeRuntime
     let onLogout: () -> Void
@@ -67,9 +76,17 @@ final class HomeCoordinator: ObservableObject {
     }()
 
     private let haptics = IosHaptics()
+    private let qrScanner: IosQrScanner?
+    private let attendanceRepository: AttendanceRepository
+    private var qrScanCompletion: ((QrScanResult) -> Void)?
+    private let prepareCheckInOverride: ((QrPreparationRequest, SecretValue) async -> QrPreparationResult)?
+    private let checkInOverride: ((QrAttendancePayload, SecretValue, SecretValue) async -> QrCheckInResult)?
+    private let qrScanLaunchGuard = QrScanLaunchGuard()
     private var homeHost: HomeBridgeHostAdapter?
     private var toastTask: Task<Void, Never>?
+    private var qrTask: Task<Void, Never>?
     private var didStart = false
+    private var releaseQrGuardOnDismiss = false
     private weak var settingsWebHolder: WebViewHolder?
 
     var colorScheme: ColorScheme? {
@@ -84,10 +101,22 @@ final class HomeCoordinator: ObservableObject {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     }
 
-    init(authRuntime: IosAuthRuntime, onLogout: @escaping () -> Void) {
-        self.homeRuntime = IosHomeRuntime.companion.create(dependencies: authRuntime.dependencies)
+    init(
+        authRuntime: IosAuthRuntime,
+        onLogout: @escaping () -> Void,
+        qrScanner: IosQrScanner? = nil,
+        attendanceRepository: AttendanceRepository? = nil,
+        prepareCheckIn: ((QrPreparationRequest, SecretValue) async -> QrPreparationResult)? = nil,
+        checkIn: ((QrAttendancePayload, SecretValue, SecretValue) async -> QrCheckInResult)? = nil
+    ) {
+        let dependencies = authRuntime.dependencies
+        self.homeRuntime = IosHomeRuntime.companion.create(dependencies: dependencies)
         self.onLogout = onLogout
         self.theme = homeRuntime.currentTheme()
+        self.qrScanner = qrScanner
+        self.attendanceRepository = attendanceRepository ?? dependencies.attendanceRepository
+        self.prepareCheckInOverride = prepareCheckIn
+        self.checkInOverride = checkIn
     }
 
     func start() {
@@ -322,7 +351,103 @@ final class HomeCoordinator: ObservableObject {
         showToast("곧 지원 예정입니다.")
     }
 
+    func startQrCheckIn(
+        subjectId: String,
+        subjectName: String,
+        yearHakgi: String,
+        requireParsedTerm: Bool
+    ) {
+        guard qrScanLaunchGuard.tryAcquire() else { return }
+        guard let session = sessionToken,
+              !subjectId.isEmpty,
+              !subjectName.isEmpty else {
+            qrScanLaunchGuard.release()
+            showToast(
+                requireParsedTerm
+                    ? "QR출석을 위한 정보를 불러오지 못했어요. 다시 시도해주세요."
+                    : "출석 정보를 확인하지 못했습니다."
+            )
+            return
+        }
+        guard let term = yearAndSemester(from: yearHakgi, requireParsedTerm: requireParsedTerm) else {
+            qrScanLaunchGuard.release()
+            showToast("QR출석을 위한 정보를 불러오지 못했어요. 다시 시도해주세요.")
+            return
+        }
+        qrPhase = .preparing
+        qrTask = Task { @MainActor in
+            var scannerLaunched = false
+            defer {
+                if !scannerLaunched {
+                    if qrPhase == .preparing { qrPhase = .idle }
+                    qrScanLaunchGuard.release()
+                }
+            }
+            let request = QrPreparationRequest(
+                year: term.year,
+                semester: term.semester,
+                subjectId: subjectId,
+                subjectName: subjectName
+            )
+            let prepared = await prepareAttendance(request, session: session)
+            guard !Task.isCancelled else { return }
+            if let success = prepared as? QrPreparationResultSuccess {
+                qrPhase = .idle
+                scannerLaunched = true
+                await scanAndCheckIn(payload: success.payload, session: session)
+                return
+            }
+            if prepared is QrPreparationResultUnsupportedSubject {
+                showToast("QR출석이 지원되지 않는 강의입니다.")
+                return
+            }
+            if prepared is QrPreparationResultSessionExpired {
+                presentQrSessionExpired()
+                return
+            }
+            showToast("출석 정보를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.")
+        }
+    }
+
+    func dismissQrAlert() {
+        qrPhase = .idle
+        if releaseQrGuardOnDismiss {
+            qrScanLaunchGuard.release()
+            releaseQrGuardOnDismiss = false
+        }
+    }
+
+    var usesOverlayQrScanner: Bool { qrScanner == nil }
+
+    func finishQrScan(_ result: QrScanResult) {
+        guard qrScanCompletion != nil || isPresentingQrScanner else { return }
+        isPresentingQrScanner = false
+        let completion = qrScanCompletion
+        qrScanCompletion = nil
+        completion?(result)
+    }
+
+    var qrAlertTitle: String {
+        if case let .result(title, _) = qrPhase { return title }
+        return ""
+    }
+
+    var qrAlertMessage: String {
+        if case let .result(_, message) = qrPhase { return message }
+        return ""
+    }
+
+    var isQrAlertPresented: Bool {
+        if case .result = qrPhase { return true }
+        return false
+    }
+
     func dispose() {
+        qrTask?.cancel()
+        qrTask = nil
+        qrScanLaunchGuard.release()
+        qrPhase = .idle
+        finishQrScan(QrScanResultCancelled())
         let holder = homeHolder
         homeHolder = nil
         holder?.dispose()
@@ -470,6 +595,175 @@ final class HomeCoordinator: ObservableObject {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .nilIfEmpty ?? "Mozilla/5.0"
     }
+
+    private func scanAndCheckIn(payload: QrAttendancePayload, session: SecretValue) async {
+        let scan = await performScan()
+        guard !Task.isCancelled else {
+            qrScanLaunchGuard.release()
+            return
+        }
+        if scan is QrScanResultCancelled {
+            qrScanLaunchGuard.release()
+            return
+        }
+        if scan is QrScanResultPermissionRequired {
+            presentQrResult(
+                title: "QR 스캔 실패",
+                message: "카메라 권한을 허용해주세요."
+            )
+            return
+        }
+        if let failed = scan as? QrScanResultFailed {
+            presentQrResult(
+                title: "QR 스캔 실패",
+                message: scannerFailureMessage(failed.reason)
+            )
+            return
+        }
+        guard let success = scan as? QrScanResultSuccess else {
+            qrScanLaunchGuard.release()
+            return
+        }
+        qrPhase = .authenticating
+        let checked = await submitCheckIn(payload: payload, session: session, scanned: SecretValue.companion.of(value: success.value))
+        guard !Task.isCancelled else {
+            qrScanLaunchGuard.release()
+            qrPhase = .idle
+            return
+        }
+        if checked is QrCheckInResultSuccess {
+            _ = haptics.performLegacy(contractName: "CONFIRM")
+            presentQrResult(title: "출석 체크 성공", message: "정상적으로 출석 처리 되었습니다.")
+            return
+        }
+        if let rejected = checked as? QrCheckInResultRejected {
+            _ = haptics.performLegacy(contractName: "REJECT")
+            presentQrResult(
+                title: "출석 체크 실패",
+                message: rejectedMessages(rejected)
+            )
+            return
+        }
+        presentQrResult(title: "오류 발생", message: "출석 체크 중 오류가 발생했습니다. \(checkInErrorMessage(checked))")
+    }
+
+    private func performScan() async -> QrScanResult {
+        if let qrScanner {
+            isPresentingQrScanner = true
+            defer { isPresentingQrScanner = false }
+            return await qrScanner.scan()
+        }
+        return await withCheckedContinuation { continuation in
+            qrScanCompletion = { continuation.resume(returning: $0) }
+            isPresentingQrScanner = true
+        }
+    }
+
+    private func presentQrResult(title: String, message: String) {
+        releaseQrGuardOnDismiss = true
+        qrPhase = .result(title: title, message: message)
+    }
+
+    private func presentQrSessionExpired() {
+        path = NavigationPath()
+        qrPhase = .idle
+        bootstrapPhase = .sessionExpired
+    }
+
+    private func prepareAttendance(
+        _ request: QrPreparationRequest,
+        session: SecretValue
+    ) async -> QrPreparationResult {
+        if let prepareCheckInOverride {
+            return await prepareCheckInOverride(request, session)
+        }
+        return await withCheckedContinuation { continuation in
+            attendanceRepository.prepareCheckIn(
+                session: session,
+                userAgent: klasUserAgent(),
+                request: request,
+                completionHandler: { result, _ in
+                    continuation.resume(returning: result ?? QrPreparationResultNetworkFailure.shared)
+                }
+            )
+        }
+    }
+
+    private func submitCheckIn(
+        payload: QrAttendancePayload,
+        session: SecretValue,
+        scanned: SecretValue
+    ) async -> QrCheckInResult {
+        if let checkInOverride {
+            return await checkInOverride(payload, session, scanned)
+        }
+        return await withCheckedContinuation { continuation in
+            attendanceRepository.checkIn(
+                session: session,
+                userAgent: klasUserAgent(),
+                payload: payload,
+                scannedCode: scanned,
+                completionHandler: { result, _ in
+                    continuation.resume(returning: result ?? QrCheckInResultNetworkFailure.shared)
+                }
+            )
+        }
+    }
+
+    private func klasUserAgent() -> KlasUserAgent {
+        KlasUserAgent.companion.fromPlatform(value: Self.platformUserAgent())
+    }
+
+    private func yearAndSemester(
+        from yearHakgi: String,
+        requireParsedTerm: Bool
+    ) -> (year: String, semester: String)? {
+        if let term = AcademicTermKey.companion.parse(value: yearHakgi) {
+            return (term.year, term.semester)
+        }
+        if requireParsedTerm { return nil }
+        let now = Date()
+        let calendar = Calendar.current
+        let year = String(calendar.component(.year, from: now))
+        let month = calendar.component(.month, from: now)
+        let semester = month < 8 ? "1" : "2"
+        return (year, semester)
+    }
+
+    private func scannerFailureMessage(_ reason: String) -> String {
+        switch reason {
+        case "scanner_camera_permission_required":
+            return "카메라 권한을 허용해주세요."
+        case "scanner_unavailable":
+            return "이 기기에서는 카메라를 사용할 수 없습니다."
+        default:
+            return "QR 스캔 중 오류가 발생했습니다: \(reason)"
+        }
+    }
+
+    private func checkInErrorMessage(_ result: QrCheckInResult) -> String {
+        if result is QrCheckInResultSessionExpired {
+            return "로그인 세션이 만료되었습니다. 앱을 재시작한 후 다시 시도해보세요."
+        }
+        if result is QrCheckInResultTimeout {
+            return "서버 응답 시간이 초과되었습니다."
+        }
+        if result is QrCheckInResultNetworkFailure {
+            return "네트워크 연결을 확인해주세요."
+        }
+        if let http = result as? QrCheckInResultHttpFailure {
+            return "서버 오류: \(http.statusCode)"
+        }
+        if result is QrCheckInResultEmptyResponse {
+            return "응답 내용이 비어있습니다."
+        }
+        return "서버 응답을 처리하지 못했습니다."
+    }
+
+    private func rejectedMessages(_ rejected: QrCheckInResultRejected) -> String {
+        let values = rejected.messages as? [String] ?? (rejected.messages as? NSArray as? [String]) ?? []
+        return values.joined(separator: " ")
+    }
 }
 
 private extension String {
@@ -516,7 +810,14 @@ final class HomeBridgeHostAdapter: HomeBridgeHost {
     }
 
     func qrCheckIn(subjId: String, subjName: String) {
-        Task { @MainActor in coordinator?.presentUnavailable() }
+        Task { @MainActor in
+            coordinator?.startQrCheckIn(
+                subjectId: subjId,
+                subjectName: subjName,
+                yearHakgi: coordinator?.yearHakgi ?? "",
+                requireParsedTerm: false
+            )
+        }
     }
 
     func openDateTimePicker(currentDateTime: String?, isStart: Bool) {

--- a/iosApp/iosApp/HomeOverlays.swift
+++ b/iosApp/iosApp/HomeOverlays.swift
@@ -54,6 +54,39 @@ struct HomeOverlayModifier: ViewModifier {
                 .onAppear { datePickerDetent = .large }
                 .preferredColorScheme(coordinator.colorScheme)
             }
+            .fullScreenCover(
+                isPresented: Binding(
+                    get: { coordinator.isPresentingQrScanner && coordinator.usesOverlayQrScanner },
+                    set: { if !$0 { coordinator.finishQrScan(QrScanResultCancelled()) } }
+                )
+            ) {
+                QrDataScannerView { result in
+                    coordinator.finishQrScan(result)
+                }
+                .ignoresSafeArea()
+            }
+            .overlay {
+                switch coordinator.qrPhase {
+                case .preparing:
+                    KlasLoadingView(message: "불러오는 중")
+                case .authenticating:
+                    KlasLoadingView(message: "인증 중")
+                        .accessibilityIdentifier("qr_check_in_loading")
+                default:
+                    EmptyView()
+                }
+            }
+            .alert(
+                coordinator.qrAlertTitle,
+                isPresented: Binding(
+                    get: { coordinator.isQrAlertPresented },
+                    set: { if !$0 { coordinator.dismissQrAlert() } }
+                )
+            ) {
+                Button("확인") { coordinator.dismissQrAlert() }
+            } message: {
+                Text(coordinator.qrAlertMessage)
+            }
             .overlay(alignment: .bottom) {
                 if let toast = coordinator.toastMessage {
                     GeometryReader { proxy in

--- a/iosApp/iosApp/HomeRootView.swift
+++ b/iosApp/iosApp/HomeRootView.swift
@@ -27,7 +27,6 @@ struct HomeRootView: View {
         .preferredColorScheme(coordinator.colorScheme)
         .tint(KlasTheme.primary)
         .onAppear { coordinator.start() }
-        .onDisappear { coordinator.dispose() }
         .homeOverlays(coordinator)
     }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>QR 출석을 위해 카메라를 사용합니다.</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>앱 잠금을 해제하기 위해 Face ID를 사용합니다.</string>
 	<key>UILaunchStoryboardName</key>

--- a/iosApp/iosApp/IosQrScanner.swift
+++ b/iosApp/iosApp/IosQrScanner.swift
@@ -1,0 +1,194 @@
+import AVFoundation
+import Shared
+import SwiftUI
+import UIKit
+import VisionKit
+
+@MainActor
+protocol QrScanPresenting: AnyObject {
+    func scan(from presenter: UIViewController?, completion: @escaping (QrScanResult) -> Void)
+}
+
+@MainActor
+final class IosQrScanner {
+    private let presenter: QrScanPresenting
+
+    init(presenter: QrScanPresenting) {
+        self.presenter = presenter
+    }
+
+    func scan(from viewController: UIViewController? = nil) async -> QrScanResult {
+        await withCheckedContinuation { continuation in
+            presenter.scan(from: viewController) { result in
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
+    static func mapBarcode(value: String?, isQr: Bool) -> QrScanResult {
+        guard let value, !value.isEmpty else { return QrScanResultCancelled() }
+        guard isQr else { return QrScanResultFailed(reason: "unsupported_barcode_format") }
+        return QrScanResultSuccess(value: value)
+    }
+
+    static func mapAvailability(
+        isSupported: Bool,
+        isAvailable: Bool,
+        permission: AVAuthorizationStatus
+    ) -> QrScanResult? {
+        switch permission {
+        case .denied, .restricted:
+            return QrScanResultPermissionRequired()
+        default:
+            break
+        }
+        if !isSupported || !isAvailable {
+            return QrScanResultFailed(reason: "scanner_unavailable")
+        }
+        return nil
+    }
+}
+
+struct QrDataScannerView: UIViewControllerRepresentable {
+    var onResult: (QrScanResult) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onResult: onResult)
+    }
+
+    func makeUIViewController(context: Context) -> QrScannerHostController {
+        let host = QrScannerHostController()
+        host.onReady = { [weak host] in
+            guard let host else { return }
+            context.coordinator.start(in: host)
+        }
+        return host
+    }
+
+    func updateUIViewController(_ host: QrScannerHostController, context: Context) {
+        context.coordinator.onResult = onResult
+        host.onReady = { [weak host] in
+            guard let host else { return }
+            context.coordinator.start(in: host)
+        }
+    }
+
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        var onResult: (QrScanResult) -> Void
+        private var started = false
+        private var finished = false
+        weak var scanner: DataScannerViewController?
+
+        init(onResult: @escaping (QrScanResult) -> Void) {
+            self.onResult = onResult
+        }
+
+        func start(in host: UIViewController) {
+            guard !started else { return }
+            started = true
+            let permission = AVCaptureDevice.authorizationStatus(for: .video)
+            if permission == .notDetermined {
+                AVCaptureDevice.requestAccess(for: .video) { [weak self, weak host] granted in
+                    DispatchQueue.main.async {
+                        guard let self, let host else { return }
+                        if granted {
+                            self.showScanner(in: host)
+                        } else {
+                            self.finish(QrScanResultPermissionRequired())
+                        }
+                    }
+                }
+                return
+            }
+            showScanner(in: host)
+        }
+
+        private func showScanner(in host: UIViewController) {
+            if let blocked = IosQrScanner.mapAvailability(
+                isSupported: DataScannerViewController.isSupported,
+                isAvailable: DataScannerViewController.isAvailable,
+                permission: AVCaptureDevice.authorizationStatus(for: .video)
+            ) {
+                finish(blocked)
+                return
+            }
+            let scanner = DataScannerViewController(
+                recognizedDataTypes: [.barcode(symbologies: [.qr])],
+                qualityLevel: .balanced,
+                recognizesMultipleItems: false,
+                isHighFrameRateTrackingEnabled: false,
+                isHighlightingEnabled: true
+            )
+            scanner.delegate = self
+            host.addChild(scanner)
+            scanner.view.frame = host.view.bounds
+            scanner.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            host.view.addSubview(scanner.view)
+            scanner.didMove(toParent: host)
+            self.scanner = scanner
+
+            let cancel = UIButton(type: .system)
+            cancel.setTitle("취소", for: .normal)
+            cancel.titleLabel?.font = .preferredFont(forTextStyle: .body)
+            cancel.addTarget(self, action: #selector(cancelScan), for: .touchUpInside)
+            cancel.translatesAutoresizingMaskIntoConstraints = false
+            host.view.addSubview(cancel)
+            NSLayoutConstraint.activate([
+                cancel.leadingAnchor.constraint(equalTo: host.view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+                cancel.topAnchor.constraint(equalTo: host.view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            ])
+
+            do {
+                try scanner.startScanning()
+            } catch {
+                finish(QrScanResultFailed(reason: "scanner_start_failed"))
+            }
+        }
+
+        func dataScanner(
+            _ dataScanner: DataScannerViewController,
+            didAdd addedItems: [RecognizedItem],
+            allItems: [RecognizedItem]
+        ) {
+            guard case let .barcode(barcode) = addedItems.first else { return }
+            dataScanner.stopScanning()
+            finish(IosQrScanner.mapBarcode(value: barcode.payloadStringValue, isQr: true))
+        }
+
+        func dataScanner(
+            _ dataScanner: DataScannerViewController,
+            becameUnavailableWithError error: DataScannerViewController.ScanningUnavailable
+        ) {
+            if case .cameraRestricted = error {
+                finish(QrScanResultPermissionRequired())
+            } else {
+                finish(QrScanResultFailed(reason: "scanner_unavailable"))
+            }
+        }
+
+        @objc func cancelScan() {
+            scanner?.stopScanning()
+            finish(QrScanResultCancelled())
+        }
+
+        func finish(_ result: QrScanResult) {
+            guard !finished else { return }
+            finished = true
+            onResult(result)
+        }
+    }
+}
+
+final class QrScannerHostController: UIViewController {
+    var onReady: (() -> Void)?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .black
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        onReady?()
+    }
+}

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -336,7 +336,15 @@ final class LectureHostAdapter: LectureBridgeHost {
     }
 
     func openQRScan() {
-        Task { @MainActor in model?.coordinator?.presentUnavailable() }
+        Task { @MainActor in
+            guard let model else { return }
+            model.coordinator?.startQrCheckIn(
+                subjectId: model.subjectId,
+                subjectName: model.subjectName,
+                yearHakgi: model.yearSemester,
+                requireParsedTerm: true
+            )
+        }
     }
 }
 

--- a/iosApp/iosAppTests/QrAttendanceTests.swift
+++ b/iosApp/iosAppTests/QrAttendanceTests.swift
@@ -1,0 +1,340 @@
+import AVFoundation
+import Foundation
+import Shared
+import UIKit
+import XCTest
+@testable import kw_klas_plus
+
+@MainActor
+final class QrAttendanceTests: XCTestCase {
+    func testSuccessfulCheckInShowsResultAlert() async {
+        let payload = Self.samplePayload()
+        let scanner = FakeQrScanPresenter(result: QrScanResultSuccess(value: "scanned"))
+        let coordinator = makeCoordinator(
+            scanner: scanner,
+            prepare: { _, _ in QrPreparationResultSuccess(payload: payload) },
+            checkIn: { _, _, _ in QrCheckInResultSuccess.shared }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: false
+        )
+        await waitUntil { coordinator.isQrAlertPresented }
+
+        XCTAssertEqual(coordinator.qrAlertTitle, "출석 체크 성공")
+        XCTAssertEqual(coordinator.qrAlertMessage, "정상적으로 출석 처리 되었습니다.")
+        XCTAssertEqual(scanner.scanCount, 1)
+        coordinator.dismissQrAlert()
+        XCTAssertEqual(coordinator.qrPhase, .idle)
+    }
+
+    func testCancelledScanLeavesIdleWithoutAlert() async {
+        let payload = Self.samplePayload()
+        let scanner = FakeQrScanPresenter(result: QrScanResultCancelled())
+        let coordinator = makeCoordinator(
+            scanner: scanner,
+            prepare: { _, _ in QrPreparationResultSuccess(payload: payload) },
+            checkIn: { _, _, _ in
+                XCTFail("check-in must not run after cancel")
+                return QrCheckInResultSuccess.shared
+            }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: false
+        )
+        await waitUntil { scanner.scanCount == 1 && coordinator.qrPhase == .idle }
+
+        XCTAssertFalse(coordinator.isQrAlertPresented)
+        XCTAssertNil(coordinator.toastMessage)
+        XCTAssertEqual(coordinator.qrPhase, .idle)
+        XCTAssertNotNil(coordinator.homeHolder)
+    }
+
+    func testCancelFromLectureKeepsLectureWhenCoveredViewWouldDispose() async {
+        let payload = Self.samplePayload()
+        let scanner = FakeQrScanPresenter(result: QrScanResultCancelled())
+        scanner.holdUntilReleased = true
+        let coordinator = makeCoordinator(
+            scanner: scanner,
+            prepare: { _, _ in QrPreparationResultSuccess(payload: payload) },
+            checkIn: { _, _, _ in QrCheckInResultSuccess.shared }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        coordinator.openLecture(subjectId: "subj", subjectName: "공통 테스트")
+        XCTAssertEqual(coordinator.path.count, 1)
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: true
+        )
+        await waitUntil { coordinator.isPresentingQrScanner }
+
+        if !coordinator.isPresentingQrScanner {
+            coordinator.dispose()
+        }
+        XCTAssertNotNil(coordinator.homeHolder)
+        XCTAssertEqual(coordinator.path.count, 1)
+
+        scanner.releasePending()
+        await waitUntil { !coordinator.isPresentingQrScanner && coordinator.qrPhase == .idle }
+
+        XCTAssertEqual(coordinator.path.count, 1)
+        XCTAssertNotNil(coordinator.homeHolder)
+        XCTAssertEqual(coordinator.bootstrapPhase, .ready)
+    }
+
+    func testDuplicateLaunchIsIgnoredUntilReleased() async {
+        let payload = Self.samplePayload()
+        let scanner = FakeQrScanPresenter(result: QrScanResultCancelled())
+        scanner.holdUntilReleased = true
+        let coordinator = makeCoordinator(
+            scanner: scanner,
+            prepare: { _, _ in QrPreparationResultSuccess(payload: payload) },
+            checkIn: { _, _, _ in QrCheckInResultSuccess.shared }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: false
+        )
+        await waitUntil { scanner.scanCount == 1 }
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: false
+        )
+        XCTAssertEqual(scanner.scanCount, 1)
+
+        scanner.releasePending()
+        await waitUntil { coordinator.qrPhase == .idle }
+        XCTAssertEqual(scanner.scanCount, 1)
+    }
+
+    func testUnsupportedSubjectShowsToast() async {
+        var prepareCount = 0
+        let scanner = FakeQrScanPresenter(result: QrScanResultCancelled())
+        let coordinator = makeCoordinator(
+            scanner: scanner,
+            prepare: { _, _ in
+                prepareCount += 1
+                return QrPreparationResultUnsupportedSubject.shared
+            },
+            checkIn: { _, _, _ in QrCheckInResultSuccess.shared }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: false
+        )
+        await waitUntil { coordinator.toastMessage != nil }
+
+        XCTAssertEqual(coordinator.toastMessage, "QR출석이 지원되지 않는 강의입니다.")
+        XCTAssertEqual(prepareCount, 1)
+        XCTAssertEqual(scanner.scanCount, 0)
+        XCTAssertEqual(coordinator.qrPhase, .idle)
+    }
+
+    func testPermissionRequiredShowsScanFailure() async {
+        let payload = Self.samplePayload()
+        let scanner = FakeQrScanPresenter(result: QrScanResultPermissionRequired())
+        let coordinator = makeCoordinator(
+            scanner: scanner,
+            prepare: { _, _ in QrPreparationResultSuccess(payload: payload) },
+            checkIn: { _, _, _ in QrCheckInResultSuccess.shared }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: false
+        )
+        await waitUntil { coordinator.isQrAlertPresented }
+
+        XCTAssertEqual(coordinator.qrAlertTitle, "QR 스캔 실패")
+        XCTAssertEqual(coordinator.qrAlertMessage, "카메라 권한을 허용해주세요.")
+    }
+
+    func testPrepareSessionExpiredGoesToExpiredPhase() async {
+        let coordinator = makeCoordinator(
+            scanner: FakeQrScanPresenter(result: QrScanResultCancelled()),
+            prepare: { _, _ in QrPreparationResultSessionExpired.shared },
+            checkIn: { _, _, _ in QrCheckInResultSuccess.shared }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "2026,1",
+            requireParsedTerm: false
+        )
+        await waitUntil { coordinator.bootstrapPhase == .sessionExpired }
+
+        XCTAssertEqual(coordinator.bootstrapPhase, .sessionExpired)
+        XCTAssertEqual(coordinator.qrPhase, .idle)
+    }
+
+    func testLectureMissingTermShowsToast() {
+        let coordinator = makeCoordinator(
+            scanner: FakeQrScanPresenter(result: QrScanResultCancelled()),
+            prepare: { _, _ in
+                XCTFail("prepare must not run without a parsed term")
+                return QrPreparationResultUnsupportedSubject.shared
+            },
+            checkIn: { _, _, _ in QrCheckInResultSuccess.shared }
+        )
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.startQrCheckIn(
+            subjectId: "subj",
+            subjectName: "공통 테스트",
+            yearHakgi: "",
+            requireParsedTerm: true
+        )
+        XCTAssertEqual(coordinator.toastMessage, "QR출석을 위한 정보를 불러오지 못했어요. 다시 시도해주세요.")
+        XCTAssertEqual(coordinator.qrPhase, .idle)
+    }
+
+    func testMapBarcodeAndAvailability() {
+        XCTAssertTrue(IosQrScanner.mapBarcode(value: nil, isQr: true) is QrScanResultCancelled)
+        XCTAssertTrue(IosQrScanner.mapBarcode(value: "", isQr: true) is QrScanResultCancelled)
+        XCTAssertTrue(IosQrScanner.mapBarcode(value: "abc", isQr: false) is QrScanResultFailed)
+        XCTAssertEqual((IosQrScanner.mapBarcode(value: "abc", isQr: true) as? QrScanResultSuccess)?.value, "abc")
+
+        XCTAssertTrue(
+            IosQrScanner.mapAvailability(
+                isSupported: true,
+                isAvailable: true,
+                permission: .denied
+            ) is QrScanResultPermissionRequired
+        )
+        XCTAssertTrue(
+            IosQrScanner.mapAvailability(
+                isSupported: false,
+                isAvailable: true,
+                permission: .authorized
+            ) is QrScanResultFailed
+        )
+        XCTAssertNil(
+            IosQrScanner.mapAvailability(
+                isSupported: true,
+                isAvailable: true,
+                permission: .authorized
+            )
+        )
+    }
+
+    private func makeCoordinator(
+        scanner: FakeQrScanPresenter,
+        prepare: @escaping (QrPreparationRequest, SecretValue) async -> QrPreparationResult,
+        checkIn: @escaping (QrAttendancePayload, SecretValue, SecretValue) async -> QrCheckInResult
+    ) -> HomeCoordinator {
+        let suite = "com.icecream.kwklasplus.test.qr.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return HomeCoordinator(
+            authRuntime: IosAuthRuntime.companion.create(defaults: defaults),
+            onLogout: {},
+            qrScanner: IosQrScanner(presenter: scanner),
+            prepareCheckIn: prepare,
+            checkIn: checkIn
+        )
+    }
+
+    private static func readyHomeResult() -> HomeBootstrapResultReady {
+        HomeBootstrapResultReady(
+            sessionToken: SecretValue.companion.of(value: "session"),
+            yearHakgi: "2026,1",
+            yearHakgiListJoined: "2026,1",
+            timetableJson: "{}",
+            deadlineJson: "[]",
+            promptYearHakgiChange: false
+        )
+    }
+
+    private static func samplePayload() -> QrAttendancePayload {
+        QrAttendancePayload(
+            list: [],
+            selectYear: "2026",
+            selectHakgi: "1",
+            openMajorCode: "",
+            openGrade: "",
+            openGwamokNo: "",
+            bunbanNo: "",
+            gwamokKname: "공통 테스트",
+            codeName1: "",
+            hakjumNum: "",
+            sisuNum: "",
+            memberName: "",
+            currentNum: "",
+            yoil: "",
+            subj: "subj",
+            randomKey: "k"
+        )
+    }
+
+    private func waitUntil(timeout: TimeInterval = 2, _ predicate: @escaping () -> Bool) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return }
+            try? await Task.sleep(nanoseconds: 20_000_000)
+        }
+        XCTAssertTrue(predicate(), "condition not met before timeout")
+    }
+}
+
+@MainActor
+private final class FakeQrScanPresenter: QrScanPresenting {
+    var result: QrScanResult
+    var holdUntilReleased = false
+    private(set) var scanCount = 0
+    private var pending: ((QrScanResult) -> Void)?
+
+    init(result: QrScanResult) {
+        self.result = result
+    }
+
+    func scan(from presenter: UIViewController?, completion: @escaping (QrScanResult) -> Void) {
+        scanCount += 1
+        if holdUntilReleased {
+            pending = completion
+            return
+        }
+        completion(result)
+    }
+
+    func releasePending() {
+        let completion = pending
+        pending = nil
+        completion?(result)
+    }
+}

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
@@ -4,6 +4,7 @@ import com.icecream.kwklasplus.core.academic.AcademicRepository
 import com.icecream.kwklasplus.core.academic.DeadlineRepository
 import com.icecream.kwklasplus.core.academic.IosDeadlineDateParsers
 import com.icecream.kwklasplus.core.academic.TimetableRepository
+import com.icecream.kwklasplus.core.attendance.AttendanceRepository
 import com.icecream.kwklasplus.core.auth.CredentialStore
 import com.icecream.kwklasplus.core.auth.IosCredentialStore
 import com.icecream.kwklasplus.core.auth.IosHttpAuthDriver
@@ -49,6 +50,10 @@ class IosSharedDependencies(
 
     val academicRepository: AcademicRepository by lazy {
         AcademicRepository(KlasSessionHttpClient(httpClient))
+    }
+
+    val attendanceRepository: AttendanceRepository by lazy {
+        AttendanceRepository(KlasSessionHttpClient(httpClient))
     }
 
     val timetableRepository: TimetableRepository by lazy {


### PR DESCRIPTION
## Summary

- M7-002 / F-019. Home `qrCheckIn`, Lecture `openQRScan` stub을 공통 `AttendanceRepository` + VisionKit `DataScannerViewController`에 연결합니다.
- 흐름은 Android와 같습니다. prepare → 스캔 → checkIn → 성공/실패 alert.
- 스캐너는 창 루트가 아니라 SwiftUI `fullScreenCover`로 띄웁니다. 강의에서 취소해도 NavigationStack이 홈으로 빠지지 않습니다.

## Test Plan

- `iosAppTests/QrAttendanceTests`
  - 성공, 취소, 강의에서 취소 후 강의 유지, 중복 실행, 미지원 강의, 권한, 세션 만료, Lecture 학기 없음
- 실기기: 카메라/권한 팝업이 뜨고 스캐너가 열리는 것까지 확인
- 실기기: 강의에서 QR 열고 취소 → 강의 화면 유지
- 실기기: 임의 QR 스캔 → `인증 중` → `출석 체크 실패` alert → 강의 유지
- 실제 수업 QR로 출석 성공 (수업 QR이 없어 이번 PR에서는 미수행)

https://github.com/user-attachments/assets/305637df-d09e-49bc-a993-8baca953b8e7