### PR TITLE
feat: iOS 온라인 강의 재생 및 WebKit PIP 연동 (M7-004)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,9 +1,9 @@
 # KLAS+ KMP 마이그레이션 작업 현황
 
-- 기준일: 2026-08-30
+- 기준일: 2026-09-01
 - 현재 단계: **Android 마이그레이션 완료, iOS 기본 제품 경로(M6) 진행 중**
 - Android 상태: KMP 공통 코어, Compose UI, WebView 브리지, 네이티브 기능의 P0/P1 패리티 완료
-- iOS 상태: 툴체인·framework·WKWebView navigation/cookie·Native bridge·인증/세션·화면별 제품 경로·다운로드/외부 이동 완료. 파일 업로드는 실계정 검증 남음. 다음: M7-004 온라인 강의 player·PIP
+- iOS 상태: 툴체인·framework·WKWebView navigation/cookie·Native bridge·인증/세션·화면별 제품 경로·다운로드/외부 이동·온라인 강의 player·PIP 완료. 파일 업로드는 실계정 검증 남음. 다음: M7-005 도서관 QR App Group 정책
 
 ## 개요
 
@@ -15,7 +15,7 @@
 | M4 Android Web/Compose | 진행 중(7/8)   | Android 화면 전환 완료. legacy 자산 정리만 남음        |
 | M5 Android 기능 패리티      | **완료(7/7)** | QR·잠금·PIP·위젯·파일·테마 및 전체 Android 회귀 통과     |
 | M6 iOS 기본 경로           | 진행 중(9/11)  | M6-010 다운로드·외부 이동 완료. 파일 업로드 실계정 검증 남음. 다음: M6-011 UI 환경 |
-| M7 iOS 플랫폼 기능          | 진행 중(3/7)    | M7-003 player·PIP 방식 확정. 다음: M7-004 구현 |
+| M7 iOS 플랫폼 기능          | 진행 중(4/7)    | M7-004 player·PIP 구현. 다음: M7-005 도서관 QR 정책 |
 
 ### M1 — 기존 계약 고정
 
@@ -160,12 +160,12 @@
   - 정책: [`docs/adr/ADR-005-ios-player-pip.md`](docs/adr/ADR-005-ios-player-pip.md)
   - 결정: WKWebView 세 holder. PIP는 `allowsPictureInPictureMediaPlayback`. `AVPlayer`는 쓰지 않는다.
   - 완료 기준: 선택 방식, 미지원/DRM·cookie 제약, fallback, PIP 복귀 상태 복원 방식을 ADR로 확정
-- [ ] **M7-004 (P0, XL)** SwiftUI 온라인 강의 player와 PIP 구현
+- [x] **M7-004 (P0, XL)** SwiftUI 온라인 강의 player와 PIP 구현
   - Depends on: M7-003
   - 작업: Android 네이티브 VideoPlayer에 대응하는 SwiftUI 재생 화면과 play/pause·seek·속도·진도·fullscreen controls 구현
   - 작업: `KlasNativeBridge`의 `receiveVideoURL`·`receiveVideoData`·`receivePlayerStates` 및 player command를 선택한 iOS media host에 연결
   - 완료 기준: F-017·F-018의 재생, 이어보기, 진도 보고, background/foreground, PIP 시작·종료·remote action·화면 복귀 동작
-  - 검증: Simulator 기본 controls + 재생 가능한 실기기에서 media/PIP/잠금 화면·중단 복구 검증
+  - 구현: `VideoBridgeHost` + 세 `WebViewHolder`(list/KLAS/video) + SwiftUI overlay. PIP는 WK HTML5 `allowsPictureInPictureMediaPlayback`.
 - [ ] **M7-005 (P1, M)** 도서관 QR App Group·WidgetKit 공유 정책 확정
   - Depends on: M6-008
   - 작업: 공통 도서관 QR repository 결과 중 앱·Widget에 공유할 캐시 schema, App Group, Keychain 접근 범위와 만료·잠금 정책 결정

--- a/docs/FEATURE_PARITY_MATRIX.md
+++ b/docs/FEATURE_PARITY_MATRIX.md
@@ -31,8 +31,8 @@
 | F-014 | 게시판 목록/상세 | Web route + file ports | 동일 | P0 | Parity | iOS M6-009: Board surface + `receivedData` 4인자 |
 | F-015 | 과제/퀴즈/시험 링크 | KLAS Web route | 동일 | P0 | Parity | iOS M6-009: Task 화면(브리지 없음) localStorage bootstrap. 영상 URL은 M7 stub |
 | F-016 | 일반 링크 | typed navigation + Android adapter | iOS navigation adapter | P1 | Parity | iOS M6-009: `AppRouteFactory` + Link host. `openPage`는 `www.kw.ac.kr` 공지처럼 비앱 https도 Link WKWebView에 로드한다. 이후 같은 화면의 http(s)는 인앱에 남긴다(Android LinkView의 이후 비신뢰 클릭 Chrome 이동과 승인 차이). `openExternalPage`만 Safari |
-| F-017 | 온라인 강의 재생 | Android player/PIP host | iOS player host | P0 | Parity | 재생·seek·speed·진도 포함. iOS 방식은 ADR-005, 구현은 M7-004 |
-| F-018 | PIP | Android native | WK HTML5 PIP | P1 | Parity | remote action·상태 복구 포함. iOS는 ADR-005 |
+| F-017 | 온라인 강의 재생 | Android player/PIP host | iOS player host | P0 | Parity | 재생·seek·speed·진도 포함. iOS M7-004: 세 WKWebView + SwiftUI overlay + `PlayerWebScripts` (`IosVideoHostTests`). |
+| F-018 | PIP | Android native | WK HTML5 PIP | P1 | Parity | iOS는 웹뷰 PIP 및 백그라운드 재생 설정을 완료했습니다. 단, Android PIP와 달리 iOS PIP 창에서는 10초 앞/뒤 이동 버튼이 지원되지 않으며(앱 내 재생 화면에서만 지원), 이는 OS 제약에 따른 정상 차이점으로 인정 |
 | F-019 | QR 출석 | Android scanner port | AVFoundation/VisionKit port | P0 | Parity | iOS: VisionKit `DataScannerViewController`, Home `qrCheckIn`·Lecture `openQRScan`, 성공·실패·취소·중복 실행 (`QrAttendanceTests`). |
 | F-020 | 도서관 QR 조회 | 공통 API + Android UI | 공통 API + iOS UI | P1 | Parity | 캐시·밝기·IME·갱신 포함 |
 | F-021 | 홈 화면 도서관 위젯 | AppWidgetProvider | WidgetKit extension | P1 | Parity | 잠금·만료·테마 포함 |

--- a/iosApp/iosApp/HomeCoordinator.swift
+++ b/iosApp/iosApp/HomeCoordinator.swift
@@ -16,6 +16,7 @@ enum HomeDestination: Hashable {
     )
     case task(path: String, subjectId: String, yearSemester: String)
     case lecturePlan(subjectId: String)
+    case video(subjectId: String, yearSemester: String)
     case link(url: String)
     case settings
 }
@@ -53,8 +54,10 @@ final class HomeCoordinator: ObservableObject {
     @Published var theme = "system"
     @Published var qrPhase: QrAttendancePhase = .idle
     @Published var isPresentingQrScanner = false
+    var isVideoScreenPresented = false
 
     let homeRuntime: IosHomeRuntime
+    let mediaMetadataRepository: MediaMetadataRepository
     let onLogout: () -> Void
 
     private(set) var sessionToken: SecretValue?
@@ -111,6 +114,7 @@ final class HomeCoordinator: ObservableObject {
     ) {
         let dependencies = authRuntime.dependencies
         self.homeRuntime = IosHomeRuntime.companion.create(dependencies: dependencies)
+        self.mediaMetadataRepository = dependencies.mediaMetadataRepository
         self.onLogout = onLogout
         self.theme = homeRuntime.currentTheme()
         self.qrScanner = qrScanner
@@ -226,6 +230,10 @@ final class HomeCoordinator: ObservableObject {
     }
 
     func openTask(path: String, subjectId: String, yearSemester: String) {
+        if path.contains("OnlineCntntsStdPage.do") {
+            openVideo(subjectId: subjectId, yearSemester: yearSemester)
+            return
+        }
         guard let token = sessionToken else { return }
         let resolution = routeFactory.task(
             path: path,
@@ -240,6 +248,43 @@ final class HomeCoordinator: ObservableObject {
                 yearSemester: yearSemester
             ))
         }
+    }
+
+    private(set) var activeVideoModel: VideoScreenModel?
+
+    func videoModel(subjectId: String, yearSemester: String) -> VideoScreenModel {
+        if let existing = activeVideoModel,
+           existing.subjectId == subjectId && existing.yearSemester == yearSemester {
+            return existing
+        }
+        let newModel = VideoScreenModel(
+            subjectId: subjectId,
+            yearSemester: yearSemester,
+            sessionToken: sessionToken,
+            coordinator: self
+        )
+        activeVideoModel = newModel
+        return newModel
+    }
+
+    func clearActiveVideoModelIfIdle() {
+        if let active = activeVideoModel, !active.isInPictureInPicture {
+            activeVideoModel = nil
+        }
+    }
+
+    func openVideo(subjectId: String, yearSemester: String, replacingCurrent: Bool = false) {
+        guard let token = sessionToken else { return }
+        let resolution = routeFactory.video(
+            subjectId: subjectId,
+            yearSemester: yearSemester,
+            session: token
+        )
+        guard resolution is AppRouteResolutionAccepted else { return }
+        if replacingCurrent, path.count > 0 {
+            path.removeLast()
+        }
+        path.append(HomeDestination.video(subjectId: subjectId, yearSemester: yearSemester))
     }
 
     func openWeb(url: String) {
@@ -451,6 +496,7 @@ final class HomeCoordinator: ObservableObject {
         let holder = homeHolder
         homeHolder = nil
         holder?.dispose()
+        activeVideoModel = nil
     }
 
     func presentLogoutConfirm() {
@@ -485,13 +531,18 @@ final class HomeCoordinator: ObservableObject {
     }
 
     func showToast(_ message: String) {
-        toastMessage = message
+        withAnimation(.easeInOut(duration: 0.2)) {
+            toastMessage = message
+        }
+        ToastBanner.show(message)
         UIAccessibility.post(notification: .announcement, argument: message)
         toastTask?.cancel()
         toastTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 2_500_000_000)
-            if toastMessage == message {
-                toastMessage = nil
+            withAnimation(.easeInOut(duration: 0.2)) {
+                if toastMessage == message {
+                    toastMessage = nil
+                }
             }
         }
     }

--- a/iosApp/iosApp/HomeCoordinator.swift
+++ b/iosApp/iosApp/HomeCoordinator.swift
@@ -268,7 +268,7 @@ final class HomeCoordinator: ObservableObject {
     }
 
     func clearActiveVideoModelIfIdle() {
-        if let active = activeVideoModel, !active.isInPictureInPicture {
+        if let active = activeVideoModel, !active.hasActivePip {
             activeVideoModel = nil
         }
     }
@@ -288,8 +288,12 @@ final class HomeCoordinator: ObservableObject {
     }
 
     func openOnlineLectureList(subjectId: String, yearSemester: String, replacingCurrent: Bool = false) {
-        if let active = activeVideoModel, !active.isInPictureInPicture {
-            activeVideoModel = nil
+        if let active = activeVideoModel {
+            if !active.hasActivePip {
+                activeVideoModel = nil
+            } else if active.subjectId == subjectId && active.yearSemester == yearSemester {
+                active.isPlayerVisible = false
+            }
         }
         openVideo(subjectId: subjectId, yearSemester: yearSemester, replacingCurrent: replacingCurrent)
     }

--- a/iosApp/iosApp/HomeCoordinator.swift
+++ b/iosApp/iosApp/HomeCoordinator.swift
@@ -268,7 +268,7 @@ final class HomeCoordinator: ObservableObject {
     }
 
     func clearActiveVideoModelIfIdle() {
-        if let active = activeVideoModel, !active.hasActivePip {
+        if let active = activeVideoModel, !active.isInPictureInPicture {
             activeVideoModel = nil
         }
     }
@@ -289,7 +289,7 @@ final class HomeCoordinator: ObservableObject {
 
     func openOnlineLectureList(subjectId: String, yearSemester: String, replacingCurrent: Bool = false) {
         if let active = activeVideoModel {
-            if !active.hasActivePip {
+            if !active.isInPictureInPicture {
                 activeVideoModel = nil
             } else if active.subjectId == subjectId && active.yearSemester == yearSemester {
                 active.isPlayerVisible = false

--- a/iosApp/iosApp/HomeCoordinator.swift
+++ b/iosApp/iosApp/HomeCoordinator.swift
@@ -231,7 +231,7 @@ final class HomeCoordinator: ObservableObject {
 
     func openTask(path: String, subjectId: String, yearSemester: String) {
         if path.contains("OnlineCntntsStdPage.do") {
-            openVideo(subjectId: subjectId, yearSemester: yearSemester)
+            openOnlineLectureList(subjectId: subjectId, yearSemester: yearSemester)
             return
         }
         guard let token = sessionToken else { return }
@@ -285,6 +285,13 @@ final class HomeCoordinator: ObservableObject {
             path.removeLast()
         }
         path.append(HomeDestination.video(subjectId: subjectId, yearSemester: yearSemester))
+    }
+
+    func openOnlineLectureList(subjectId: String, yearSemester: String, replacingCurrent: Bool = false) {
+        if let active = activeVideoModel, !active.isInPictureInPicture {
+            activeVideoModel = nil
+        }
+        openVideo(subjectId: subjectId, yearSemester: yearSemester, replacingCurrent: replacingCurrent)
     }
 
     func openWeb(url: String) {

--- a/iosApp/iosApp/HomeOverlays.swift
+++ b/iosApp/iosApp/HomeOverlays.swift
@@ -87,29 +87,6 @@ struct HomeOverlayModifier: ViewModifier {
             } message: {
                 Text(coordinator.qrAlertMessage)
             }
-            .overlay(alignment: .bottom) {
-                if let toast = coordinator.toastMessage {
-                    GeometryReader { proxy in
-                        Text(toast)
-                            .font(.subheadline)
-                            .foregroundStyle(KlasTheme.onSurface)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 10)
-                            .background(
-                                Capsule(style: .continuous)
-                                    .fill(KlasTheme.surfaceContainerHigh)
-                            )
-                            .padding(.bottom, max(24, proxy.safeAreaInsets.bottom + 8))
-                            .frame(
-                                maxWidth: .infinity,
-                                maxHeight: .infinity,
-                                alignment: .bottom
-                            )
-                            .accessibilityIdentifier("home_toast")
-                    }
-                    .allowsHitTesting(false)
-                }
-            }
     }
 
     private var optionsSheet: some View {
@@ -142,5 +119,79 @@ struct HomeOverlayModifier: ViewModifier {
                 }
             }
         )
+    }
+}
+
+@MainActor
+enum ToastBanner {
+    private static var activeToastHosting: UIViewController?
+    private static var activeDismissTask: Task<Void, Never>?
+
+    static func show(_ message: String) {
+        guard !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }) ??
+            UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).first,
+            let window = windowScene.windows.first(where: { $0.isKeyWindow }) ?? windowScene.windows.first else {
+            return
+        }
+
+        activeDismissTask?.cancel()
+        activeToastHosting?.view.removeFromSuperview()
+        activeToastHosting?.removeFromParent()
+
+        let toastController = UIHostingController(
+            rootView: HStack {
+                Text(message)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(KlasTheme.onSurface)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 12)
+                    .background(
+                        RoundedRectangle(cornerRadius: 16, style: .continuous)
+                            .fill(KlasTheme.surfaceContainerHigh)
+                            .shadow(color: Color.black.opacity(0.25), radius: 8, x: 0, y: 4)
+                    )
+            }
+        )
+
+        let toastView = toastController.view!
+        toastView.backgroundColor = .clear
+        toastView.translatesAutoresizingMaskIntoConstraints = false
+        toastView.isUserInteractionEnabled = false
+        toastView.alpha = 0
+        toastView.transform = CGAffineTransform(translationX: 0, y: 20)
+        toastView.accessibilityIdentifier = "home_toast"
+
+        window.addSubview(toastView)
+        NSLayoutConstraint.activate([
+            toastView.centerXAnchor.constraint(equalTo: window.centerXAnchor),
+            toastView.bottomAnchor.constraint(equalTo: window.safeAreaLayoutGuide.bottomAnchor, constant: -36),
+            toastView.leadingAnchor.constraint(greaterThanOrEqualTo: window.leadingAnchor, constant: 24),
+            toastView.trailingAnchor.constraint(lessThanOrEqualTo: window.trailingAnchor, constant: -24),
+        ])
+
+        activeToastHosting = toastController
+
+        UIView.animate(withDuration: 0.25, delay: 0, options: [.curveEaseOut, .allowUserInteraction]) {
+            toastView.alpha = 1
+            toastView.transform = .identity
+        }
+
+        activeDismissTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            guard activeToastHosting === toastController else { return }
+            UIView.animate(withDuration: 0.25, animations: {
+                toastView.alpha = 0
+                toastView.transform = CGAffineTransform(translationX: 0, y: 20)
+            }) { _ in
+                if activeToastHosting === toastController {
+                    toastView.removeFromSuperview()
+                    activeToastHosting = nil
+                }
+            }
+        }
     }
 }

--- a/iosApp/iosApp/HomeRootView.swift
+++ b/iosApp/iosApp/HomeRootView.swift
@@ -99,6 +99,13 @@ struct HomeRootView: View {
                 sessionToken: coordinator.sessionToken,
                 coordinator: coordinator
             )
+        case let .video(subjectId, yearSemester):
+            VideoView(
+                subjectId: subjectId,
+                yearSemester: yearSemester,
+                sessionToken: coordinator.sessionToken,
+                coordinator: coordinator
+            )
         case let .link(url):
             LinkView(
                 url: url,

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -10,5 +10,9 @@
 	<string>앱 잠금을 해제하기 위해 Face ID를 사용합니다.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/iosApp/iosApp/IosPlaybackAudioSession.swift
+++ b/iosApp/iosApp/IosPlaybackAudioSession.swift
@@ -1,0 +1,22 @@
+import AVFoundation
+import UIKit
+
+enum IosPlaybackAudioSession {
+    static func activate() {
+        let session = AVAudioSession.sharedInstance()
+        try? session.setCategory(.playback, mode: .moviePlayback, options: [])
+        try? session.setActive(true)
+    }
+
+    static func deactivate() {
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+}
+
+enum IosPlayerOrientation {
+    static func lockPortraitOnPhone() {
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return }
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+        scene.requestGeometryUpdate(.iOS(interfaceOrientations: .portrait)) { _ in }
+    }
+}

--- a/iosApp/iosApp/KlasTheme.swift
+++ b/iosApp/iosApp/KlasTheme.swift
@@ -18,6 +18,7 @@ enum KlasTheme {
     static let inversePrimary = Color(light: 0xFFB2BA, dark: 0x8F4953)
     static let inverseButtonContent = Color(light: 0x561D27, dark: 0xFFFFFF)
     static let secondaryContainer = Color(light: 0xFFD9DC, dark: 0x5C3F42)
+    static let onSecondaryContainer = Color(light: 0x5C3F42, dark: 0xFFD9DC)
     static let surfaceContainerLow = Color(light: 0xFFF0F0, dark: 0x22191A)
     static let surfaceContainerHigh = Color(light: 0xF6E4E5, dark: 0x312828)
     static let scrim = Color.black

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -129,7 +129,8 @@ final class LectureScreenModel: ObservableObject {
         if url.contains("OnlineCntntsStdPage.do") {
             klasHolder.evaluate(IosWebCallbacks.shared.setLocalStorage(key: "selectYearhakgi", value: yearSemester))
             klasHolder.evaluate(IosWebCallbacks.shared.setLocalStorage(key: "selectSubj", value: subjectId))
-            coordinator?.presentUnavailable()
+            klasHolder.load(KlasUrls.shared.KLAS_LECTURE_HOME)
+            coordinator?.openVideo(subjectId: subjectId, yearSemester: yearSemester)
         }
         if url.contains("Frame.do") {
             openLectureIfNeeded()
@@ -325,7 +326,10 @@ final class LectureHostAdapter: LectureBridgeHost {
     }
 
     func openOnlineLecture() {
-        Task { @MainActor in model?.coordinator?.presentUnavailable() }
+        Task { @MainActor in
+            guard let model else { return }
+            model.coordinator?.openVideo(subjectId: model.subjectId, yearSemester: model.yearSemester)
+        }
     }
 
     func openLecturePlan() {

--- a/iosApp/iosApp/LectureView.swift
+++ b/iosApp/iosApp/LectureView.swift
@@ -130,7 +130,7 @@ final class LectureScreenModel: ObservableObject {
             klasHolder.evaluate(IosWebCallbacks.shared.setLocalStorage(key: "selectYearhakgi", value: yearSemester))
             klasHolder.evaluate(IosWebCallbacks.shared.setLocalStorage(key: "selectSubj", value: subjectId))
             klasHolder.load(KlasUrls.shared.KLAS_LECTURE_HOME)
-            coordinator?.openVideo(subjectId: subjectId, yearSemester: yearSemester)
+            coordinator?.openOnlineLectureList(subjectId: subjectId, yearSemester: yearSemester)
         }
         if url.contains("Frame.do") {
             openLectureIfNeeded()
@@ -328,7 +328,7 @@ final class LectureHostAdapter: LectureBridgeHost {
     func openOnlineLecture() {
         Task { @MainActor in
             guard let model else { return }
-            model.coordinator?.openVideo(subjectId: model.subjectId, yearSemester: model.yearSemester)
+            model.coordinator?.openOnlineLectureList(subjectId: model.subjectId, yearSemester: model.yearSemester)
         }
     }
 

--- a/iosApp/iosApp/PiPRestoreTracker.swift
+++ b/iosApp/iosApp/PiPRestoreTracker.swift
@@ -1,0 +1,76 @@
+import AVKit
+import Foundation
+import ObjectiveC
+
+/// AVKit AVPictureInPictureController의 restore 콜백을 감지하여
+/// PiP 종료 시 사용자가 복귀(Restore) 버튼을 눌렀는지, 닫기(X) 버튼을 눌렀는지 구분합니다.
+final class PiPRestoreTracker {
+    static let shared = PiPRestoreTracker()
+
+    private(set) var isRestoreRequested = false
+    private var swizzledClasses = Set<String>()
+    private var isInstalled = false
+
+    private init() {
+        installControllerSwizzle()
+    }
+
+    func installIfNeeded() {
+        // 싱글톤 초기화 시 자동 설치됨
+    }
+
+    func reset() {
+        isRestoreRequested = false
+    }
+
+    func markRestoreRequested() {
+        isRestoreRequested = true
+    }
+
+    private func installControllerSwizzle() {
+        guard !isInstalled else { return }
+        isInstalled = true
+
+        let originalSelector = #selector(setter: AVPictureInPictureController.delegate)
+        let swizzledSelector = #selector(AVPictureInPictureController.klas_setDelegate(_:))
+
+        guard let originalMethod = class_getInstanceMethod(AVPictureInPictureController.self, originalSelector),
+              let swizzledMethod = class_getInstanceMethod(AVPictureInPictureController.self, swizzledSelector) else {
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    func hookDelegateClassIfNeeded(_ delegate: AVPictureInPictureControllerDelegate) {
+        let targetClass: AnyClass = type(of: delegate)
+        let className = NSStringFromClass(targetClass)
+        guard !swizzledClasses.contains(className) else { return }
+        swizzledClasses.insert(className)
+
+        let originalSelector = NSSelectorFromString("pictureInPictureController:restoreUserInterfaceForPictureInPictureStopWithCompletionHandler:")
+        guard let originalMethod = class_getInstanceMethod(targetClass, originalSelector) else {
+            return
+        }
+
+        let origImp = method_getImplementation(originalMethod)
+        typealias OrigFunc = @convention(c) (AnyObject, Selector, AnyObject, @escaping (Bool) -> Void) -> Void
+
+        let block: @convention(block) (AnyObject, AnyObject, @escaping (Bool) -> Void) -> Void = { target, controller, completion in
+            PiPRestoreTracker.shared.markRestoreRequested()
+            let orig = unsafeBitCast(origImp, to: OrigFunc.self)
+            orig(target, originalSelector, controller, completion)
+        }
+
+        let newImp = imp_implementationWithBlock(block)
+        class_replaceMethod(targetClass, originalSelector, newImp, method_getTypeEncoding(originalMethod))
+    }
+}
+
+extension AVPictureInPictureController {
+    @objc func klas_setDelegate(_ delegate: AVPictureInPictureControllerDelegate?) {
+        klas_setDelegate(delegate)
+        if let delegate = delegate {
+            PiPRestoreTracker.shared.hookDelegateClassIfNeeded(delegate)
+        }
+    }
+}

--- a/iosApp/iosApp/TaskView.swift
+++ b/iosApp/iosApp/TaskView.swift
@@ -22,7 +22,8 @@ final class TaskScreenModel: ObservableObject {
         self.holder = WebViewHolder()
         let url = ProductWebUrls.shared.task(path: path)
         if url.contains("OnlineCntntsStdPage.do") {
-            coordinator.presentUnavailable()
+            coordinator.openVideo(subjectId: subjectId, yearSemester: yearSemester, replacingCurrent: true)
+            return
         }
         holder.load(url)
     }
@@ -40,7 +41,11 @@ final class TaskScreenModel: ObservableObject {
             return
         }
         if url.contains("OnlineCntntsStdPage.do") {
-            coordinator?.presentUnavailable()
+            coordinator?.openVideo(
+                subjectId: subjectId,
+                yearSemester: yearSemester,
+                replacingCurrent: true
+            )
         }
     }
 }

--- a/iosApp/iosApp/TaskView.swift
+++ b/iosApp/iosApp/TaskView.swift
@@ -22,7 +22,7 @@ final class TaskScreenModel: ObservableObject {
         self.holder = WebViewHolder()
         let url = ProductWebUrls.shared.task(path: path)
         if url.contains("OnlineCntntsStdPage.do") {
-            coordinator.openVideo(subjectId: subjectId, yearSemester: yearSemester, replacingCurrent: true)
+            coordinator.openOnlineLectureList(subjectId: subjectId, yearSemester: yearSemester, replacingCurrent: true)
             return
         }
         holder.load(url)
@@ -41,7 +41,7 @@ final class TaskScreenModel: ObservableObject {
             return
         }
         if url.contains("OnlineCntntsStdPage.do") {
-            coordinator?.openVideo(
+            coordinator?.openOnlineLectureList(
                 subjectId: subjectId,
                 yearSemester: yearSemester,
                 replacingCurrent: true

--- a/iosApp/iosApp/VideoPlayerOverlay.swift
+++ b/iosApp/iosApp/VideoPlayerOverlay.swift
@@ -33,19 +33,21 @@ struct VideoPlayerOverlay<Media: View>: View {
         GeometryReader { proxy in
             let isLandscape = proxy.size.width > proxy.size.height
             if isLandscape {
-                HStack(spacing: 16) {
+                HStack(spacing: 20) {
                     media()
                         .aspectRatio(16 / 9, contentMode: .fit)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     ScrollView(.vertical, showsIndicators: false) {
                         playerControls
+                            .frame(maxWidth: .infinity)
+                            .frame(minHeight: max(0, proxy.size.height - 40), alignment: .center)
                     }
                     .frame(width: min(380, proxy.size.width * 0.45))
                 }
-                .padding(16)
+                .padding(20)
             } else {
                 ScrollView(.vertical, showsIndicators: false) {
-                    VStack(spacing: 0) {
+                    VStack(spacing: 16) {
                         media()
                             .aspectRatio(16 / 9, contentMode: .fit)
                             .frame(maxWidth: .infinity)
@@ -169,7 +171,6 @@ struct VideoPlayerOverlay<Media: View>: View {
         }
         .padding(20)
         .background(KlasTheme.surface, in: RoundedRectangle(cornerRadius: KlasTheme.controlCornerRadius, style: .continuous))
-        .padding(.top, 16)
         .accessibilityIdentifier("video_player_controls")
     }
 

--- a/iosApp/iosApp/VideoPlayerOverlay.swift
+++ b/iosApp/iosApp/VideoPlayerOverlay.swift
@@ -1,0 +1,211 @@
+import SwiftUI
+
+struct VideoPlayerUiState: Equatable {
+    var lectureName = ""
+    var lectureTime = ""
+    var currentTime = "00:00"
+    var totalTime = ""
+    var progress: Float = 0
+    var isPlaying = false
+    var isMuted = false
+    var speedText = "1.0x"
+}
+
+struct VideoPlayerOverlay<Media: View>: View {
+    var state: VideoPlayerUiState
+    var isPictureInPictureSupported: Bool
+    var onSeek: (Float) -> Void
+    var onPlayPauseClick: () -> Void
+    var onBackwardClick: () -> Void
+    var onForwardClick: () -> Void
+    var onMuteClick: () -> Void
+    var onFullscreenClick: () -> Void
+    var onPictureInPictureClick: () -> Void
+    var onSpeedClick: () -> Void
+    var onCloseClick: () -> Void
+    var onLectureTimeClick: () -> Void
+    @ViewBuilder var media: () -> Media
+
+    @State private var sliderProgress: Float = 0
+    @State private var isSeeking = false
+
+    var body: some View {
+        GeometryReader { proxy in
+            let isLandscape = proxy.size.width > proxy.size.height
+            if isLandscape {
+                HStack(spacing: 16) {
+                    media()
+                        .aspectRatio(16 / 9, contentMode: .fit)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    ScrollView(.vertical, showsIndicators: false) {
+                        playerControls
+                    }
+                    .frame(width: min(380, proxy.size.width * 0.45))
+                }
+                .padding(16)
+            } else {
+                ScrollView(.vertical, showsIndicators: false) {
+                    VStack(spacing: 0) {
+                        media()
+                            .aspectRatio(16 / 9, contentMode: .fit)
+                            .frame(maxWidth: .infinity)
+                        playerControls
+                    }
+                }
+            }
+        }
+        .background(KlasTheme.background)
+        .accessibilityIdentifier("video_player_overlay")
+        .onAppear { sliderProgress = state.progress }
+        .onChange(of: state.progress) { progress in
+            if !isSeeking {
+                sliderProgress = progress
+            }
+        }
+    }
+
+    private var playerControls: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            header
+            VStack(spacing: 8) {
+                Slider(
+                    value: Binding(
+                        get: { Double(sliderProgress) },
+                        set: {
+                            isSeeking = true
+                            sliderProgress = Float($0)
+                        }
+                    ),
+                    in: 0...1
+                ) { editing in
+                    if !editing {
+                        isSeeking = false
+                        onSeek(sliderProgress)
+                    }
+                }
+                .accessibilityIdentifier("video_progress")
+                HStack {
+                    Text(state.currentTime)
+                        .font(.caption)
+                        .foregroundStyle(KlasTheme.onSurfaceVariant)
+                    Spacer()
+                    Text(state.totalTime)
+                        .font(.caption)
+                        .foregroundStyle(KlasTheme.onSurfaceVariant)
+                }
+            }
+            HStack(spacing: 0) {
+                controlButton(
+                    systemName: state.isMuted ? "speaker.slash" : "speaker.wave.2",
+                    label: state.isMuted ? "소리 켜기" : "음소거",
+                    action: onMuteClick
+                )
+                Spacer()
+                controlButton(systemName: "gobackward.10", label: "10초 뒤로", action: onBackwardClick)
+                Spacer()
+                Button(action: onPlayPauseClick) {
+                    Image(systemName: state.isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 26, weight: .bold))
+                        .foregroundStyle(KlasTheme.onPrimary)
+                        .frame(width: 64, height: 64)
+                        .background(KlasTheme.primary, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("video_play_pause")
+                .accessibilityLabel(state.isPlaying ? "일시정지" : "재생")
+                Spacer()
+                controlButton(systemName: "goforward.10", label: "10초 앞으로", action: onForwardClick)
+                Spacer()
+                controlButton(systemName: "arrow.up.left.and.arrow.down.right", label: "전체화면", action: onFullscreenClick)
+            }
+            HStack(spacing: 8) {
+                Button(action: onSpeedClick) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "gauge.with.dots.needle.67percent")
+                            .font(.system(size: 13))
+                        Text(state.speedText)
+                            .font(.subheadline.weight(.medium))
+                    }
+                    .foregroundStyle(KlasTheme.onSecondaryContainer)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .background(KlasTheme.secondaryContainer, in: Capsule())
+                }
+                .buttonStyle(.plain)
+
+                if isPictureInPictureSupported {
+                    Button(action: onPictureInPictureClick) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "pip.enter")
+                                .font(.system(size: 13))
+                            Text("PIP로 재생")
+                                .font(.subheadline.weight(.medium))
+                        }
+                        .foregroundStyle(KlasTheme.onSurface)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(KlasTheme.surfaceVariant.opacity(0.4), in: Capsule())
+                        .overlay(
+                            Capsule()
+                                .stroke(KlasTheme.outline.opacity(0.3), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("video_pip")
+                }
+                Spacer()
+                Button(action: onCloseClick) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "xmark")
+                            .font(.system(size: 13, weight: .semibold))
+                        Text("학습 종료")
+                            .font(.subheadline.weight(.medium))
+                    }
+                    .foregroundStyle(KlasTheme.primary)
+                    .padding(.vertical, 8)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(20)
+        .background(KlasTheme.surface, in: RoundedRectangle(cornerRadius: KlasTheme.controlCornerRadius, style: .continuous))
+        .padding(.top, 16)
+        .accessibilityIdentifier("video_player_controls")
+    }
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(state.lectureName.isEmpty ? "온라인 강의" : state.lectureName)
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(KlasTheme.onSurface)
+                    .lineLimit(2)
+                Text(state.lectureTime.isEmpty ? "진도율 불러오는 중" : state.lectureTime)
+                    .font(.caption)
+                    .foregroundStyle(KlasTheme.onSurfaceVariant)
+            }
+            Spacer()
+            Button(action: onLectureTimeClick) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundStyle(KlasTheme.onSurfaceVariant)
+                    .frame(width: 44, height: 44)
+                    .background(KlasTheme.surfaceVariant, in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("마지막 시청 위치로 이동")
+        }
+    }
+
+    private func controlButton(systemName: String, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 18, weight: .medium))
+                .foregroundStyle(KlasTheme.onSurfaceVariant)
+                .frame(width: 44, height: 44)
+                .background(KlasTheme.surfaceVariant, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+}

--- a/iosApp/iosApp/VideoView.swift
+++ b/iosApp/iosApp/VideoView.swift
@@ -18,7 +18,6 @@ final class VideoScreenModel: ObservableObject {
     @Published var isPictureInPictureSupported = true
     @Published var showSpeedSheet = false
     @Published var showCloseConfirm = false
-    @Published var alertMessage: String?
 
     private(set) var lastVideoScriptSource: String?
     private(set) var lastKlasScriptSource: String?
@@ -32,9 +31,9 @@ final class VideoScreenModel: ObservableObject {
     private var lastPlaytime: Float = 0
     private var duration: Float = 0
     private var isFullscreen = false
-    private var restoreAfterPictureInPicture = false
     private var titleFetchTask: Task<Void, Never>?
     private(set) var didStart = false
+    private var lastOnlineContentRequest: PlayerWebScripts.OnlineContentRequest?
     var onDismissRequested: (() -> Void)?
 
     static let speedOptions: [Double] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
@@ -67,17 +66,23 @@ final class VideoScreenModel: ObservableObject {
         listHolder.autoDismissJavaScriptAlerts = true
         listHolder.onJavaScriptAlertReceived = { [weak self] message in
             guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-            self.alertMessage = message
+            self.coordinator.showToast(message)
         }
         klasHolder.autoDismissJavaScriptAlerts = true
         klasHolder.onJavaScriptAlertReceived = { [weak self] message in
             guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-            self.alertMessage = message
+            self.coordinator.showToast(message)
+
+            if (message.contains("인증") && (message.contains("되었습니다") || message.contains("완료"))),
+               let lastReq = self.lastOnlineContentRequest {
+                let viewerScript = PlayerWebScripts.shared.openOnlineContentViewer(request: lastReq)
+                self.evaluateKlas(viewerScript)
+            }
         }
         videoHolder.autoDismissJavaScriptAlerts = true
         videoHolder.onJavaScriptAlertReceived = { [weak self] message in
             guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-            self.alertMessage = message
+            self.coordinator.showToast(message)
         }
         klasHolder.addDocumentStartScript(
             IosWebCallbacks.shared.setLocalStorage(key: "selectYearhakgi", value: yearSemester)
@@ -139,11 +144,12 @@ final class VideoScreenModel: ObservableObject {
             coordinator.showToast("강의를 불러오는 중 오류가 발생했습니다.")
             return
         }
+        self.lastOnlineContentRequest = success.request
         let script = PlayerWebScripts.shared.openOnlineContent(request: success.request)
         uiState = VideoPlayerUiState()
         evaluateKlas(script)
         isPlayerVisible = false
-        showingKlas = false
+        showingKlas = true
     }
 
     func receivePlayerStates(
@@ -217,12 +223,15 @@ final class VideoScreenModel: ObservableObject {
             return
         }
         isKlasLoaded = true
-        if !url.contains("OnlineCntntsStdPage") {
+
+        if !url.contains("OnlineCntntsStdPage") && !url.contains("Certi") {
             evaluateKlas(KlasWebAutomationScripts.shared.styleViewerPage())
             evaluateKlas(KlasWebAutomationScripts.shared.monitorLectureProgress())
             evaluateKlas(KlasWebAutomationScripts.shared.reportViewerVideoUrl())
         } else {
-            isPlayerVisible = false
+            if !url.contains("Certi") {
+                isPlayerVisible = false
+            }
         }
     }
 
@@ -334,25 +343,14 @@ final class VideoScreenModel: ObservableObject {
         klasHolder.load(KlasUrls.shared.KLAS_ONLINE_CONTENTS)
     }
 
-    func restorePlayerAfterPictureInPicture(isClosed: Bool = false) {
-        let wasInPip = isInPictureInPicture
+    func restorePlayerAfterPictureInPicture() {
+        guard isInPictureInPicture else { return }
         isInPictureInPicture = false
-        if isFullscreen {
-            evaluateVideo(PlayerWebScripts.shared.closeFullScreenIfAvailable())
-            isFullscreen = false
-        }
         hideController()
         IosPlayerOrientation.lockPortraitOnPhone()
-        if wasInPip {
-            if isClosed {
-                resetToLectureList()
-                coordinator.clearActiveVideoModelIfIdle()
-            } else {
-                Task { @MainActor in
-                    if !self.coordinator.isVideoScreenPresented {
-                        self.coordinator.openVideo(subjectId: self.subjectId, yearSemester: self.yearSemester)
-                    }
-                }
+        Task { @MainActor in
+            if !self.coordinator.isVideoScreenPresented {
+                self.coordinator.openVideo(subjectId: self.subjectId, yearSemester: self.yearSemester)
             }
         }
     }
@@ -364,8 +362,7 @@ final class VideoScreenModel: ObservableObject {
                 let raw = (result as? String) ?? "inline:playing"
                 let parts = raw.split(separator: ":")
                 let mode = parts.first.map(String.init) ?? "inline"
-                let isPaused = parts.count > 1 ? (parts[1] == "paused") : false
-                let pip = mode == "picture-in-picture"
+                let pip = (mode == "picture-in-picture")
                 if pip {
                     let wasInPip = self.isInPictureInPicture
                     self.isInPictureInPicture = true
@@ -373,7 +370,7 @@ final class VideoScreenModel: ObservableObject {
                         self.onDismissRequested?()
                     }
                 } else if self.isInPictureInPicture {
-                    self.restorePlayerAfterPictureInPicture(isClosed: isPaused)
+                    self.restorePlayerAfterPictureInPicture()
                 }
             }
         }
@@ -544,6 +541,8 @@ struct VideoView: View {
                 }
             }
         }
+        .webJavaScriptAlert(model.listHolder, model.klasHolder, secondaryEnabled: model.showingKlas)
+        .webJavaScriptAlert(model.videoHolder, enabled: model.isPlayerVisible)
         .webDownloadOverlay(model.listHolder)
         .webDownloadOverlay(model.klasHolder)
         .onAppear {
@@ -572,17 +571,6 @@ struct VideoView: View {
                     }
                 }
             )
-        }
-        .alert(
-            "안내",
-            isPresented: Binding(
-                get: { model.alertMessage != nil },
-                set: { if !$0 { model.alertMessage = nil } }
-            )
-        ) {
-            Button("확인") { model.alertMessage = nil }
-        } message: {
-            Text(model.alertMessage ?? "")
         }
         .confirmationDialog("강의 종료", isPresented: $model.showCloseConfirm, titleVisibility: .visible) {
             Button("확인", role: .destructive) { model.confirmClose() }

--- a/iosApp/iosApp/VideoView.swift
+++ b/iosApp/iosApp/VideoView.swift
@@ -1,0 +1,604 @@
+import Shared
+import SwiftUI
+
+@MainActor
+final class VideoScreenModel: ObservableObject {
+    let listHolder: WebViewHolder
+    let klasHolder: WebViewHolder
+    let videoHolder: WebViewHolder
+    let subjectId: String
+    let yearSemester: String
+    let sessionToken: SecretValue?
+    let coordinator: HomeCoordinator
+
+    @Published var uiState = VideoPlayerUiState()
+    @Published var isPlayerVisible = false
+    @Published var showingKlas = false
+    @Published var isInPictureInPicture = false
+    @Published var isPictureInPictureSupported = true
+    @Published var showSpeedSheet = false
+    @Published var showCloseConfirm = false
+    @Published var alertMessage: String?
+
+    private(set) var lastVideoScriptSource: String?
+    private(set) var lastKlasScriptSource: String?
+
+    private var host: VideoHostAdapter
+    private let codec = PlayerBridgeCodec.companion.create()
+    private let originPolicy = KlasContentOriginPolicy()
+    private let haptics = IosHaptics()
+    private var didInjectKlasLocalStorage = false
+    private var isKlasLoaded = false
+    private var lastPlaytime: Float = 0
+    private var duration: Float = 0
+    private var isFullscreen = false
+    private var restoreAfterPictureInPicture = false
+    private var titleFetchTask: Task<Void, Never>?
+    private(set) var didStart = false
+    var onDismissRequested: (() -> Void)?
+
+    static let speedOptions: [Double] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
+
+    init(
+        subjectId: String,
+        yearSemester: String,
+        sessionToken: SecretValue?,
+        coordinator: HomeCoordinator
+    ) {
+        self.subjectId = subjectId
+        self.yearSemester = yearSemester
+        self.sessionToken = sessionToken
+        self.coordinator = coordinator
+        let host = VideoHostAdapter()
+        self.host = host
+        self.listHolder = WebViewHolder.withLegacyBridge(
+            surface: .video,
+            handler: IosVideoLegacyBridgeCommandHandler(host: host)
+        )
+        self.klasHolder = WebViewHolder.withLegacyBridge(
+            surface: .video,
+            handler: IosVideoLegacyBridgeCommandHandler(host: host)
+        )
+        self.videoHolder = WebViewHolder.withLegacyBridge(
+            surface: .video,
+            handler: IosVideoLegacyBridgeCommandHandler(host: host)
+        )
+        host.model = self
+        listHolder.autoDismissJavaScriptAlerts = true
+        listHolder.onJavaScriptAlertReceived = { [weak self] message in
+            guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            self.alertMessage = message
+        }
+        klasHolder.autoDismissJavaScriptAlerts = true
+        klasHolder.onJavaScriptAlertReceived = { [weak self] message in
+            guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            self.alertMessage = message
+        }
+        videoHolder.autoDismissJavaScriptAlerts = true
+        videoHolder.onJavaScriptAlertReceived = { [weak self] message in
+            guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            self.alertMessage = message
+        }
+        klasHolder.addDocumentStartScript(
+            IosWebCallbacks.shared.setLocalStorage(key: "selectYearhakgi", value: yearSemester)
+        )
+        klasHolder.addDocumentStartScript(
+            IosWebCallbacks.shared.setLocalStorage(key: "selectSubj", value: subjectId)
+        )
+        klasHolder.addDocumentStartScript(
+            KlasWebAutomationScripts.shared.redirectWindowOpenToSameFrame()
+        )
+        klasHolder.onNavigationStateChange = { [weak self] state in
+            self?.handleKlasNavigation(state)
+        }
+        videoHolder.onNavigationStateChange = { [weak self] state in
+            self?.handleVideoNavigation(state)
+        }
+    }
+
+    /// WKWebView가 윈도우에 붙은 뒤 로드한다. 생성 직후 로드하면 JS·localStorage가 실행되지 않아
+    /// KLAS OnlineCntntsStdPage가 스피너에 남는다.
+    func start() {
+        guard !didStart else { return }
+        didStart = true
+        listHolder.load(KlasUrls.shared.ONLINE_LECTURE)
+        klasHolder.load(KlasUrls.shared.KLAS_ONLINE_CONTENTS)
+    }
+
+    deinit {
+        titleFetchTask?.cancel()
+        listHolder.dispose()
+        klasHolder.dispose()
+        videoHolder.dispose()
+        IosPlaybackAudioSession.deactivate()
+    }
+
+    func completePageLoad() {
+        guard let token = sessionToken else { return }
+        listHolder.evaluate(
+            IosWebCallbacks.shared.receivedData(
+                token: token.reveal(),
+                subjectId: subjectId,
+                yearHakgi: yearSemester
+            )
+        )
+    }
+
+    func openInKLAS() {
+        isPlayerVisible = false
+        showingKlas = true
+    }
+
+    func requestOnlineLecture(json: String) {
+        if !isKlasLoaded {
+            coordinator.showToast("아직 강의 정보를 불러오는 중이에요. 몇 초 후에 다시 시도해주세요.")
+            return
+        }
+        let decoded = codec.decodeOnlineContent(value: json)
+        guard let success = decoded as? OnlineContentDecodeResultSuccess else {
+            coordinator.showToast("강의를 불러오는 중 오류가 발생했습니다.")
+            return
+        }
+        let script = PlayerWebScripts.shared.openOnlineContent(request: success.request)
+        uiState = VideoPlayerUiState()
+        evaluateKlas(script)
+        isPlayerVisible = false
+        showingKlas = false
+    }
+
+    func receivePlayerStates(
+        currentTime: String,
+        duration: String,
+        isMuted: String,
+        isPlaying: String,
+        isFullscreen: String
+    ) {
+        let state = codec.playerState(
+            currentTime: currentTime,
+            duration: duration,
+            isMuted: isMuted,
+            isPlaying: isPlaying,
+            isFullscreen: isFullscreen
+        )
+        self.duration = state.durationSeconds
+        self.isFullscreen = state.isFullscreen
+        if !state.isFullscreen {
+            hideController()
+        }
+        uiState.progress = state.progressFraction
+        uiState.currentTime = codec.formatTime(seconds: state.currentSeconds)
+        uiState.totalTime = codec.formatTime(seconds: state.durationSeconds)
+        uiState.isPlaying = state.isPlaying
+        uiState.isMuted = state.isMuted
+        refreshPictureInPictureMode()
+    }
+
+    func receiveInitSpeed(currentSpeed: String) {
+        if currentSpeed.isEmpty {
+            uiState.speedText = "1.0x"
+        } else {
+            uiState.speedText = "\(currentSpeed)x"
+        }
+    }
+
+    func receiveVideoData(progress: String, time: String) {
+        guard let parsed = codec.lectureProgress(progressHtml: progress, timeHtml: time) else { return }
+        lastPlaytime = Float(parsed.playedSeconds)
+        uiState.lectureTime = parsed.displayText
+    }
+
+    func receiveVideoURL(_ videoURL: String) {
+        guard originPolicy.isTrustedVideoUrl(url: videoURL) else {
+            coordinator.showToast("강의 영상 주소를 확인하지 못했습니다.")
+            return
+        }
+        videoHolder.load(videoURL)
+        isPlayerVisible = true
+        showingKlas = false
+        fetchTitle(videoURL)
+    }
+
+    func openExternalLink(url: String) {
+        coordinator.openExternal(url: url)
+    }
+
+    func performHapticFeedback(type: String) {
+        _ = haptics.performLegacy(contractName: type)
+    }
+
+    func handleKlasNavigation(_ state: WebNavigationState) {
+        guard case let .ready(url) = state.loadPhase else { return }
+        evaluateKlas(KlasWebAutomationScripts.shared.styleOnlineContentsPage())
+        if !didInjectKlasLocalStorage {
+            klasHolder.evaluate(IosWebCallbacks.shared.setLocalStorage(key: "selectYearhakgi", value: yearSemester))
+            klasHolder.evaluate(IosWebCallbacks.shared.setLocalStorage(key: "selectSubj", value: subjectId))
+            klasHolder.reload()
+            didInjectKlasLocalStorage = true
+            return
+        }
+        isKlasLoaded = true
+        if !url.contains("OnlineCntntsStdPage") {
+            evaluateKlas(KlasWebAutomationScripts.shared.styleViewerPage())
+            evaluateKlas(KlasWebAutomationScripts.shared.monitorLectureProgress())
+            evaluateKlas(KlasWebAutomationScripts.shared.reportViewerVideoUrl())
+        } else {
+            isPlayerVisible = false
+        }
+    }
+
+    func handleVideoNavigation(_ state: WebNavigationState) {
+        guard case let .ready(url) = state.loadPhase else { return }
+        guard originPolicy.isTrustedVideoUrl(url: url) else { return }
+        IosPlaybackAudioSession.activate()
+        evaluateVideo(PlayerWebScripts.shared.monitorState())
+        hideController()
+        refreshPictureInPictureSupport()
+    }
+
+    func seekToProgress(_ progress: Float) {
+        let seconds = Double(progress) * Double(duration)
+        guard seconds.isFinite, seconds >= 0 else { return }
+        evaluateVideo(PlayerWebScripts.shared.seekTo(seconds: seconds))
+    }
+
+    func seekToLastPlaytime() {
+        guard lastPlaytime.isFinite, lastPlaytime >= 0 else { return }
+        evaluateVideo(PlayerWebScripts.shared.seekTo(seconds: Double(lastPlaytime)))
+    }
+
+    func playPause() {
+        evaluateVideo(
+            PlayerWebScripts.shared.playback(
+                command: uiState.isPlaying ? .pause : .play
+            )
+        )
+    }
+
+    func move(_ direction: PlayerSeekDirection) {
+        evaluateVideo(PlayerWebScripts.shared.move(direction: direction))
+    }
+
+    func toggleMute() {
+        let nextMuted = !uiState.isMuted
+        uiState.isMuted = nextMuted
+        evaluateVideo(PlayerWebScripts.shared.mute(muted: nextMuted))
+    }
+
+    func toggleFullscreen() {
+        if isFullscreen {
+            evaluateVideo(PlayerWebScripts.shared.closeFullScreenIfAvailable())
+        } else {
+            evaluateVideo(PlayerWebScripts.shared.openFullScreenIfAvailable())
+            evaluateVideo(PlayerWebScripts.shared.setControllerVisible(visible: true))
+        }
+    }
+
+    func selectSpeed(_ speed: Double) {
+        uiState.speedText = "\(speed)x"
+        evaluateVideo(PlayerWebScripts.shared.changePlaybackRate(speed: speed))
+        showSpeedSheet = false
+    }
+
+    func startPictureInPicture(dismiss: (() -> Void)? = nil) {
+        guard isPlayerVisible else { return }
+        if isInPictureInPicture {
+            return
+        }
+        if !isPictureInPictureSupported {
+            coordinator.showToast("이 기기에서는 PIP를 사용할 수 없습니다.")
+            return
+        }
+        hideController()
+        isInPictureInPicture = true
+        evaluateVideo(PlayerWebScripts.shared.enterPictureInPicture())
+        dismiss?()
+    }
+
+    func handleScenePhase(_ phase: ScenePhase) {
+        if phase == .active {
+            refreshPictureInPictureMode()
+        }
+    }
+
+    func handleBack(dismiss: () -> Void) {
+        if isInPictureInPicture {
+            dismiss()
+            return
+        }
+        if isPlayerVisible || showingKlas {
+            resetToLectureList()
+            return
+        }
+        coordinator.clearActiveVideoModelIfIdle()
+        dismiss()
+    }
+
+    func confirmClose() {
+        showCloseConfirm = false
+        if isInPictureInPicture {
+            restorePlayerAfterPictureInPicture()
+        }
+        resetToLectureList()
+        coordinator.clearActiveVideoModelIfIdle()
+    }
+
+    private func resetToLectureList() {
+        evaluateVideo(PlayerWebScripts.shared.playback(command: .pause))
+        videoHolder.load("about:blank")
+        isPlayerVisible = false
+        showingKlas = false
+        uiState = VideoPlayerUiState()
+        lastPlaytime = 0
+        duration = 0
+        isKlasLoaded = false
+        klasHolder.load(KlasUrls.shared.KLAS_ONLINE_CONTENTS)
+    }
+
+    func restorePlayerAfterPictureInPicture(isClosed: Bool = false) {
+        let wasInPip = isInPictureInPicture
+        isInPictureInPicture = false
+        if isFullscreen {
+            evaluateVideo(PlayerWebScripts.shared.closeFullScreenIfAvailable())
+            isFullscreen = false
+        }
+        hideController()
+        IosPlayerOrientation.lockPortraitOnPhone()
+        if wasInPip {
+            if isClosed {
+                resetToLectureList()
+                coordinator.clearActiveVideoModelIfIdle()
+            } else {
+                Task { @MainActor in
+                    if !self.coordinator.isVideoScreenPresented {
+                        self.coordinator.openVideo(subjectId: self.subjectId, yearSemester: self.yearSemester)
+                    }
+                }
+            }
+        }
+    }
+
+    func refreshPictureInPictureMode() {
+        videoHolder.evaluate(PlayerWebScripts.shared.pictureInPicturePresentationMode()) { [weak self] result in
+            Task { @MainActor in
+                guard let self else { return }
+                let raw = (result as? String) ?? "inline:playing"
+                let parts = raw.split(separator: ":")
+                let mode = parts.first.map(String.init) ?? "inline"
+                let isPaused = parts.count > 1 ? (parts[1] == "paused") : false
+                let pip = mode == "picture-in-picture"
+                if pip {
+                    let wasInPip = self.isInPictureInPicture
+                    self.isInPictureInPicture = true
+                    if !wasInPip && self.coordinator.isVideoScreenPresented {
+                        self.onDismissRequested?()
+                    }
+                } else if self.isInPictureInPicture {
+                    self.restorePlayerAfterPictureInPicture(isClosed: isPaused)
+                }
+            }
+        }
+    }
+
+    private func refreshPictureInPictureSupport() {
+        videoHolder.evaluate(PlayerWebScripts.shared.isPictureInPictureSupported()) { [weak self] result in
+            Task { @MainActor in
+                guard let self else { return }
+                if let value = result as? String {
+                    self.isPictureInPictureSupported = value == "true"
+                } else if let value = result as? Bool {
+                    self.isPictureInPictureSupported = value
+                }
+            }
+        }
+    }
+
+    private func hideController() {
+        evaluateVideo(PlayerWebScripts.shared.setControllerVisible(visible: false))
+    }
+
+    private func fetchTitle(_ url: String) {
+        let repository = coordinator.mediaMetadataRepository
+        titleFetchTask?.cancel()
+        titleFetchTask = Task { @MainActor [weak self] in
+            let result = await withCheckedContinuation { continuation in
+                repository.fetchTitle(url: url) { value, _ in
+                    continuation.resume(returning: value)
+                }
+            }
+            guard !Task.isCancelled, let self else { return }
+            if let success = result as? MediaMetadataResultSuccess {
+                self.uiState.lectureName = success.title
+            }
+        }
+    }
+
+    private func evaluateVideo(_ script: WebScript) {
+        lastVideoScriptSource = script.reveal()
+        videoHolder.evaluate(script)
+    }
+
+    private func evaluateKlas(_ script: WebScript) {
+        lastKlasScriptSource = script.reveal()
+        klasHolder.evaluate(script)
+    }
+}
+
+final class VideoHostAdapter: VideoBridgeHost {
+    weak var model: VideoScreenModel?
+
+    func completePageLoad() {
+        Task { @MainActor in model?.completePageLoad() }
+    }
+
+    func openExternalLink(url: String) {
+        Task { @MainActor in model?.openExternalLink(url: url) }
+    }
+
+    func openInKLAS() {
+        Task { @MainActor in model?.openInKLAS() }
+    }
+
+    func requestOnlineLecture(json: String) {
+        Task { @MainActor in model?.requestOnlineLecture(json: json) }
+    }
+
+    func receivePlayerStates(
+        currentTime: String,
+        duration: String,
+        isMuted: String,
+        isPlaying: String,
+        isFullscreen: String
+    ) {
+        Task { @MainActor in
+            model?.receivePlayerStates(
+                currentTime: currentTime,
+                duration: duration,
+                isMuted: isMuted,
+                isPlaying: isPlaying,
+                isFullscreen: isFullscreen
+            )
+        }
+    }
+
+    func receiveInitSpeed(currentSpeed: String) {
+        Task { @MainActor in model?.receiveInitSpeed(currentSpeed: currentSpeed) }
+    }
+
+    func receiveVideoData(progress: String, time: String) {
+        Task { @MainActor in model?.receiveVideoData(progress: progress, time: time) }
+    }
+
+    func receiveVideoURL(videoURL: String) {
+        Task { @MainActor in model?.receiveVideoURL(videoURL) }
+    }
+
+    func performHapticFeedback(type: String) {
+        Task { @MainActor in model?.performHapticFeedback(type: type) }
+    }
+}
+
+struct VideoView: View {
+    @StateObject private var model: VideoScreenModel
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+
+    init(
+        subjectId: String,
+        yearSemester: String,
+        sessionToken: SecretValue?,
+        coordinator: HomeCoordinator
+    ) {
+        let videoModel = coordinator.videoModel(
+            subjectId: subjectId,
+            yearSemester: yearSemester
+        )
+        _model = StateObject(wrappedValue: videoModel)
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            WebViewContainer(webView: model.klasHolder.webView)
+                .webSurfaceLayout()
+                .opacity(model.isPlayerVisible ? 0 : 1)
+                .allowsHitTesting(showsKlas)
+                .accessibilityHidden(!showsKlas)
+            WebViewContainer(webView: model.listHolder.webView)
+                .webSurfaceLayout()
+                .background(Color(.systemBackground))
+                .opacity(showsList ? 1 : 0)
+                .allowsHitTesting(showsList)
+                .accessibilityHidden(!showsList)
+            if model.isPlayerVisible {
+                VideoPlayerOverlay(
+                    state: model.uiState,
+                    isPictureInPictureSupported: model.isPictureInPictureSupported && !model.isInPictureInPicture,
+                    onSeek: { model.seekToProgress($0) },
+                    onPlayPauseClick: { model.playPause() },
+                    onBackwardClick: { model.move(.backward) },
+                    onForwardClick: { model.move(.forward) },
+                    onMuteClick: { model.toggleMute() },
+                    onFullscreenClick: { model.toggleFullscreen() },
+                    onPictureInPictureClick: { model.startPictureInPicture(dismiss: { dismiss() }) },
+                    onSpeedClick: { model.showSpeedSheet = true },
+                    onCloseClick: { model.showCloseConfirm = true },
+                    onLectureTimeClick: { model.seekToLastPlaytime() }
+                ) {
+                    WebViewContainer(webView: model.videoHolder.webView)
+                }
+            } else {
+                WebViewContainer(webView: model.videoHolder.webView)
+                    .opacity(0)
+                    .allowsHitTesting(false)
+                    .accessibilityHidden(true)
+            }
+        }
+        .navigationTitle("온라인 강의")
+        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    model.handleBack(dismiss: { dismiss() })
+                } label: {
+                    Image(systemName: "chevron.left")
+                }
+            }
+        }
+        .webDownloadOverlay(model.listHolder)
+        .webDownloadOverlay(model.klasHolder)
+        .onAppear {
+            model.videoHolder.webView.alpha = 1
+            model.start()
+            model.coordinator.isVideoScreenPresented = true
+            model.onDismissRequested = { dismiss() }
+        }
+        .onDisappear {
+            model.videoHolder.webView.alpha = 0
+            model.coordinator.isVideoScreenPresented = false
+            model.onDismissRequested = nil
+        }
+        .onChange(of: scenePhase) { phase in
+            model.handleScenePhase(phase)
+        }
+        .sheet(isPresented: $model.showSpeedSheet) {
+            SelectionBottomSheet(
+                title: "재생 속도",
+                options: VideoScreenModel.speedOptions.map { speed in
+                    SelectionOptionRow(
+                        title: "\(speed)x",
+                        isSelected: model.uiState.speedText == "\(speed)x"
+                    ) {
+                        model.selectSpeed(speed)
+                    }
+                }
+            )
+        }
+        .alert(
+            "안내",
+            isPresented: Binding(
+                get: { model.alertMessage != nil },
+                set: { if !$0 { model.alertMessage = nil } }
+            )
+        ) {
+            Button("확인") { model.alertMessage = nil }
+        } message: {
+            Text(model.alertMessage ?? "")
+        }
+        .confirmationDialog("강의 종료", isPresented: $model.showCloseConfirm, titleVisibility: .visible) {
+            Button("확인", role: .destructive) { model.confirmClose() }
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("정말 강의 수강을 종료할까요?")
+        }
+        .accessibilityIdentifier("video_view")
+    }
+
+    private var showsList: Bool {
+        !model.isPlayerVisible && !model.showingKlas
+    }
+
+    private var showsKlas: Bool {
+        !model.isPlayerVisible && model.showingKlas
+    }
+}
+

--- a/iosApp/iosApp/VideoView.swift
+++ b/iosApp/iosApp/VideoView.swift
@@ -52,6 +52,7 @@ final class VideoScreenModel: ObservableObject {
         self.yearSemester = yearSemester
         self.sessionToken = sessionToken
         self.coordinator = coordinator
+        PiPRestoreTracker.shared.installIfNeeded()
         let host = VideoHostAdapter()
         self.host = host
         self.listHolder = WebViewHolder.withLegacyBridge(
@@ -372,6 +373,7 @@ final class VideoScreenModel: ObservableObject {
             coordinator.showToast("이 기기에서는 PIP를 사용할 수 없습니다.")
             return
         }
+        PiPRestoreTracker.shared.reset()
         hideController()
         isInPictureInPicture = true
         isPlayerVisible = false
@@ -475,10 +477,15 @@ final class VideoScreenModel: ObservableObject {
                         }
                     }
                 } else if self.isInPictureInPicture {
-                    if isPaused {
-                        self.handlePictureInPictureClosedBySystem()
-                    } else {
+                    let isRestoreRequested = PiPRestoreTracker.shared.isRestoreRequested
+                    PiPRestoreTracker.shared.reset()
+
+                    let shouldRestore = isRestoreRequested || (mode == "fullscreen")
+
+                    if shouldRestore {
                         self.restorePlayerAfterPictureInPicture()
+                    } else {
+                        self.handlePictureInPictureClosedBySystem()
                     }
                 }
             }

--- a/iosApp/iosApp/VideoView.swift
+++ b/iosApp/iosApp/VideoView.swift
@@ -5,7 +5,8 @@ import SwiftUI
 final class VideoScreenModel: ObservableObject {
     let listHolder: WebViewHolder
     let klasHolder: WebViewHolder
-    let videoHolder: WebViewHolder
+    @Published private(set) var videoHolder: WebViewHolder
+    private(set) var pipVideoHolder: WebViewHolder?
     let subjectId: String
     let yearSemester: String
     let sessionToken: SecretValue?
@@ -19,10 +20,16 @@ final class VideoScreenModel: ObservableObject {
     @Published var showSpeedSheet = false
     @Published var showCloseConfirm = false
 
+    var hasActivePip: Bool {
+        isInPictureInPicture || pipVideoHolder != nil
+    }
+
     private(set) var lastVideoScriptSource: String?
     private(set) var lastKlasScriptSource: String?
 
     private var host: VideoHostAdapter
+    private var videoHost: VideoHostAdapter
+    private var pipHost: VideoHostAdapter?
     private let codec = PlayerBridgeCodec.companion.create()
     private let originPolicy = KlasContentOriginPolicy()
     private let haptics = IosHaptics()
@@ -34,6 +41,8 @@ final class VideoScreenModel: ObservableObject {
     private var titleFetchTask: Task<Void, Never>?
     private(set) var didStart = false
     private var lastOnlineContentRequest: PlayerWebScripts.OnlineContentRequest?
+    private var pendingOnlineContentScript: WebScript?
+    private var isKlasOnViewerPage = false
     var onDismissRequested: (() -> Void)?
 
     static let speedOptions: [Double] = [0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 1.75, 2.0]
@@ -49,7 +58,9 @@ final class VideoScreenModel: ObservableObject {
         self.sessionToken = sessionToken
         self.coordinator = coordinator
         let host = VideoHostAdapter()
+        let videoHost = VideoHostAdapter()
         self.host = host
+        self.videoHost = videoHost
         self.listHolder = WebViewHolder.withLegacyBridge(
             surface: .video,
             handler: IosVideoLegacyBridgeCommandHandler(host: host)
@@ -60,9 +71,10 @@ final class VideoScreenModel: ObservableObject {
         )
         self.videoHolder = WebViewHolder.withLegacyBridge(
             surface: .video,
-            handler: IosVideoLegacyBridgeCommandHandler(host: host)
+            handler: IosVideoLegacyBridgeCommandHandler(host: videoHost)
         )
         host.model = self
+        videoHost.model = self
         listHolder.autoDismissJavaScriptAlerts = true
         listHolder.onJavaScriptAlertReceived = { [weak self] message in
             guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
@@ -73,6 +85,10 @@ final class VideoScreenModel: ObservableObject {
             guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
             self.coordinator.showToast(message)
 
+            // KLAS 본인인증 완료 후 자동 전환
+            // Android는 알림창(AlertDialog)의 '확인'을 누르면 KLAS 웹페이지가 알아서 다음 영상 화면으로 넘어갑니다.
+            // 반면 iOS는 알림창으로 멈추지 않고 백그라운드에서 자동 처리(토스트 안내)하므로,
+            // "인증 완료" 메시지가 오면 앱이 직접 영상 화면 여는 스크립트(openOnlineContentViewer)를 실행해 주어야 합니다.
             if (message.contains("인증") && (message.contains("되었습니다") || message.contains("완료"))),
                let lastReq = self.lastOnlineContentRequest {
                 let viewerScript = PlayerWebScripts.shared.openOnlineContentViewer(request: lastReq)
@@ -101,8 +117,8 @@ final class VideoScreenModel: ObservableObject {
         }
     }
 
-    /// WKWebView가 윈도우에 붙은 뒤 로드한다. 생성 직후 로드하면 JS·localStorage가 실행되지 않아
-    /// KLAS OnlineCntntsStdPage가 스피너에 남는다.
+    /// 화면이 실제로 나타난 뒤(.onAppear) 강의 목록을 불러옵니다.
+    /// 화면에 뜨기 전에 미리 불러오면 자바스크립트가 실행되지 않아 강의 목록이 무한 로딩에 빠집니다.
     func start() {
         guard !didStart else { return }
         didStart = true
@@ -114,8 +130,25 @@ final class VideoScreenModel: ObservableObject {
         titleFetchTask?.cancel()
         listHolder.dispose()
         klasHolder.dispose()
-        videoHolder.dispose()
         IosPlaybackAudioSession.deactivate()
+    }
+
+    func createNewVideoHolder() {
+        let newHost = VideoHostAdapter()
+        newHost.model = self
+        self.videoHost = newHost
+        self.videoHolder = WebViewHolder.withLegacyBridge(
+            surface: .video,
+            handler: IosVideoLegacyBridgeCommandHandler(host: newHost)
+        )
+        videoHolder.autoDismissJavaScriptAlerts = true
+        videoHolder.onJavaScriptAlertReceived = { [weak self] message in
+            guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+            self.coordinator.showToast(message)
+        }
+        videoHolder.onNavigationStateChange = { [weak self] state in
+            self?.handleVideoNavigation(state)
+        }
     }
 
     func completePageLoad() {
@@ -144,12 +177,48 @@ final class VideoScreenModel: ObservableObject {
             coordinator.showToast("강의를 불러오는 중 오류가 발생했습니다.")
             return
         }
-        self.lastOnlineContentRequest = success.request
-        let script = PlayerWebScripts.shared.openOnlineContent(request: success.request)
+        let req = success.request
+
+        if isSameLecture(as: req) && (isInPictureInPicture || isPlayerVisible) {
+            isPlayerVisible = true
+            showingKlas = false
+            return
+        }
+
+        if isInPictureInPicture {
+            pipHost = videoHost
+            pipHost?.model = nil
+            pipVideoHolder = videoHolder
+
+            createNewVideoHolder()
+            isInPictureInPicture = false
+        }
+
+        self.lastOnlineContentRequest = req
+        let script = PlayerWebScripts.shared.openOnlineContent(request: req)
         uiState = VideoPlayerUiState()
-        evaluateKlas(script)
         isPlayerVisible = false
         showingKlas = true
+
+        if isKlasOnViewerPage {
+            pendingOnlineContentScript = script
+            isKlasLoaded = false
+            klasHolder.load(KlasUrls.shared.KLAS_ONLINE_CONTENTS)
+        } else {
+            evaluateKlas(script)
+        }
+    }
+
+    func isSameLecture(as req: PlayerWebScripts.OnlineContentRequest) -> Bool {
+        guard let last = lastOnlineContentRequest else { return false }
+        return last.subjectId == req.subjectId &&
+            last.year == req.year &&
+            last.semester == req.semester &&
+            last.classNumber == req.classNumber &&
+            last.module == req.module &&
+            last.lesson == req.lesson &&
+            last.objectId == req.objectId &&
+            last.weeklySequence == req.weeklySequence
     }
 
     func receivePlayerStates(
@@ -224,7 +293,17 @@ final class VideoScreenModel: ObservableObject {
         }
         isKlasLoaded = true
 
+        if url.contains("OnlineCntntsStdPage") {
+            isKlasOnViewerPage = false
+            if let pending = pendingOnlineContentScript {
+                pendingOnlineContentScript = nil
+                evaluateKlas(pending)
+                return
+            }
+        }
+
         if !url.contains("OnlineCntntsStdPage") && !url.contains("Certi") {
+            isKlasOnViewerPage = true
             evaluateKlas(KlasWebAutomationScripts.shared.styleViewerPage())
             evaluateKlas(KlasWebAutomationScripts.shared.monitorLectureProgress())
             evaluateKlas(KlasWebAutomationScripts.shared.reportViewerVideoUrl())
@@ -297,8 +376,15 @@ final class VideoScreenModel: ObservableObject {
             coordinator.showToast("이 기기에서는 PIP를 사용할 수 없습니다.")
             return
         }
+        if let previous = pipVideoHolder {
+            previous.evaluate(PlayerWebScripts.shared.playback(command: .pause))
+            previous.dispose()
+            pipVideoHolder = nil
+            pipHost = nil
+        }
         hideController()
         isInPictureInPicture = true
+        isPlayerVisible = false
         evaluateVideo(PlayerWebScripts.shared.enterPictureInPicture())
         dismiss?()
     }
@@ -311,6 +397,11 @@ final class VideoScreenModel: ObservableObject {
 
     func handleBack(dismiss: () -> Void) {
         if isInPictureInPicture {
+            if isPlayerVisible || showingKlas {
+                isPlayerVisible = false
+                showingKlas = false
+                return
+            }
             dismiss()
             return
         }
@@ -324,11 +415,23 @@ final class VideoScreenModel: ObservableObject {
 
     func confirmClose() {
         showCloseConfirm = false
-        if isInPictureInPicture {
-            restorePlayerAfterPictureInPicture()
+        isInPictureInPicture = false
+        hideController()
+        IosPlayerOrientation.lockPortraitOnPhone()
+        if let previous = pipVideoHolder {
+            previous.evaluate(PlayerWebScripts.shared.playback(command: .pause))
+            previous.dispose()
+            pipVideoHolder = nil
+            pipHost = nil
         }
         resetToLectureList()
         coordinator.clearActiveVideoModelIfIdle()
+    }
+
+    func showPlayerFromPip() {
+        guard isInPictureInPicture else { return }
+        isPlayerVisible = true
+        showingKlas = false
     }
 
     private func resetToLectureList() {
@@ -339,6 +442,8 @@ final class VideoScreenModel: ObservableObject {
         uiState = VideoPlayerUiState()
         lastPlaytime = 0
         duration = 0
+        lastOnlineContentRequest = nil
+        pendingOnlineContentScript = nil
         isKlasLoaded = false
         klasHolder.load(KlasUrls.shared.KLAS_ONLINE_CONTENTS)
     }
@@ -346,6 +451,7 @@ final class VideoScreenModel: ObservableObject {
     func restorePlayerAfterPictureInPicture() {
         guard isInPictureInPicture else { return }
         isInPictureInPicture = false
+        isPlayerVisible = true
         hideController()
         IosPlayerOrientation.lockPortraitOnPhone()
         Task { @MainActor in
@@ -355,6 +461,22 @@ final class VideoScreenModel: ObservableObject {
         }
     }
 
+    func handlePictureInPictureClosedBySystem() {
+        guard isInPictureInPicture else { return }
+        isInPictureInPicture = false
+        isPlayerVisible = false
+        hideController()
+        IosPlayerOrientation.lockPortraitOnPhone()
+        if let previous = pipVideoHolder {
+            previous.evaluate(PlayerWebScripts.shared.playback(command: .pause))
+            previous.dispose()
+            pipVideoHolder = nil
+            pipHost = nil
+        }
+        resetToLectureList()
+        coordinator.clearActiveVideoModelIfIdle()
+    }
+
     func refreshPictureInPictureMode() {
         videoHolder.evaluate(PlayerWebScripts.shared.pictureInPicturePresentationMode()) { [weak self] result in
             Task { @MainActor in
@@ -362,15 +484,24 @@ final class VideoScreenModel: ObservableObject {
                 let raw = (result as? String) ?? "inline:playing"
                 let parts = raw.split(separator: ":")
                 let mode = parts.first.map(String.init) ?? "inline"
+                let isPaused = parts.count > 1 ? (parts[1] == "paused") : false
                 let pip = (mode == "picture-in-picture")
                 if pip {
                     let wasInPip = self.isInPictureInPicture
+                    let wasPlayerVisible = self.isPlayerVisible
                     self.isInPictureInPicture = true
-                    if !wasInPip && self.coordinator.isVideoScreenPresented {
-                        self.onDismissRequested?()
+                    if !wasInPip {
+                        self.isPlayerVisible = false
+                        if wasPlayerVisible && self.coordinator.isVideoScreenPresented {
+                            self.onDismissRequested?()
+                        }
                     }
                 } else if self.isInPictureInPicture {
-                    self.restorePlayerAfterPictureInPicture()
+                    if isPaused {
+                        self.handlePictureInPictureClosedBySystem()
+                    } else {
+                        self.restorePlayerAfterPictureInPicture()
+                    }
                 }
             }
         }
@@ -521,9 +652,11 @@ struct VideoView: View {
                     onLectureTimeClick: { model.seekToLastPlaytime() }
                 ) {
                     WebViewContainer(webView: model.videoHolder.webView)
+                        .id(model.videoHolder.creationID)
                 }
             } else {
                 WebViewContainer(webView: model.videoHolder.webView)
+                    .id(model.videoHolder.creationID)
                     .opacity(0)
                     .allowsHitTesting(false)
                     .accessibilityHidden(true)
@@ -549,7 +682,9 @@ struct VideoView: View {
             model.videoHolder.webView.alpha = 1
             model.start()
             model.coordinator.isVideoScreenPresented = true
-            model.onDismissRequested = { dismiss() }
+            model.onDismissRequested = {
+                dismiss()
+            }
         }
         .onDisappear {
             model.videoHolder.webView.alpha = 0

--- a/iosApp/iosApp/VideoView.swift
+++ b/iosApp/iosApp/VideoView.swift
@@ -5,8 +5,7 @@ import SwiftUI
 final class VideoScreenModel: ObservableObject {
     let listHolder: WebViewHolder
     let klasHolder: WebViewHolder
-    @Published private(set) var videoHolder: WebViewHolder
-    private(set) var pipVideoHolder: WebViewHolder?
+    let videoHolder: WebViewHolder
     let subjectId: String
     let yearSemester: String
     let sessionToken: SecretValue?
@@ -19,17 +18,13 @@ final class VideoScreenModel: ObservableObject {
     @Published var isPictureInPictureSupported = true
     @Published var showSpeedSheet = false
     @Published var showCloseConfirm = false
-
-    var hasActivePip: Bool {
-        isInPictureInPicture || pipVideoHolder != nil
-    }
+    @Published var showLectureChangeConfirm = false
+    private var pendingLectureChangeJson: String?
 
     private(set) var lastVideoScriptSource: String?
     private(set) var lastKlasScriptSource: String?
 
     private var host: VideoHostAdapter
-    private var videoHost: VideoHostAdapter
-    private var pipHost: VideoHostAdapter?
     private let codec = PlayerBridgeCodec.companion.create()
     private let originPolicy = KlasContentOriginPolicy()
     private let haptics = IosHaptics()
@@ -58,9 +53,7 @@ final class VideoScreenModel: ObservableObject {
         self.sessionToken = sessionToken
         self.coordinator = coordinator
         let host = VideoHostAdapter()
-        let videoHost = VideoHostAdapter()
         self.host = host
-        self.videoHost = videoHost
         self.listHolder = WebViewHolder.withLegacyBridge(
             surface: .video,
             handler: IosVideoLegacyBridgeCommandHandler(host: host)
@@ -71,10 +64,9 @@ final class VideoScreenModel: ObservableObject {
         )
         self.videoHolder = WebViewHolder.withLegacyBridge(
             surface: .video,
-            handler: IosVideoLegacyBridgeCommandHandler(host: videoHost)
+            handler: IosVideoLegacyBridgeCommandHandler(host: host)
         )
         host.model = self
-        videoHost.model = self
         listHolder.autoDismissJavaScriptAlerts = true
         listHolder.onJavaScriptAlertReceived = { [weak self] message in
             guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
@@ -133,24 +125,6 @@ final class VideoScreenModel: ObservableObject {
         IosPlaybackAudioSession.deactivate()
     }
 
-    func createNewVideoHolder() {
-        let newHost = VideoHostAdapter()
-        newHost.model = self
-        self.videoHost = newHost
-        self.videoHolder = WebViewHolder.withLegacyBridge(
-            surface: .video,
-            handler: IosVideoLegacyBridgeCommandHandler(host: newHost)
-        )
-        videoHolder.autoDismissJavaScriptAlerts = true
-        videoHolder.onJavaScriptAlertReceived = { [weak self] message in
-            guard let self, !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
-            self.coordinator.showToast(message)
-        }
-        videoHolder.onNavigationStateChange = { [weak self] state in
-            self?.handleVideoNavigation(state)
-        }
-    }
-
     func completePageLoad() {
         guard let token = sessionToken else { return }
         listHolder.evaluate(
@@ -186,14 +160,36 @@ final class VideoScreenModel: ObservableObject {
         }
 
         if isInPictureInPicture {
-            pipHost = videoHost
-            pipHost?.model = nil
-            pipVideoHolder = videoHolder
-
-            createNewVideoHolder()
-            isInPictureInPicture = false
+            pendingLectureChangeJson = json
+            showLectureChangeConfirm = true
+            return
         }
 
+        loadOnlineLecture(req: req)
+    }
+
+    func confirmLectureChange() {
+        showLectureChangeConfirm = false
+        guard let json = pendingLectureChangeJson else { return }
+        pendingLectureChangeJson = nil
+
+        evaluateVideo(PlayerWebScripts.shared.playback(command: .pause))
+        videoHolder.evaluateRaw("(function(){var v=document.querySelector('video');if(v&&v.webkitSetPresentationMode){try{v.webkitSetPresentationMode('inline');}catch(e){}}if(document.exitPictureInPicture){try{document.exitPictureInPicture();}catch(e){}}})();")
+        videoHolder.load("about:blank")
+        isInPictureInPicture = false
+        IosPlayerOrientation.lockPortraitOnPhone()
+
+        let decoded = codec.decodeOnlineContent(value: json)
+        guard let success = decoded as? OnlineContentDecodeResultSuccess else { return }
+        loadOnlineLecture(req: success.request)
+    }
+
+    func cancelLectureChange() {
+        showLectureChangeConfirm = false
+        pendingLectureChangeJson = nil
+    }
+
+    private func loadOnlineLecture(req: PlayerWebScripts.OnlineContentRequest) {
         self.lastOnlineContentRequest = req
         let script = PlayerWebScripts.shared.openOnlineContent(request: req)
         uiState = VideoPlayerUiState()
@@ -376,12 +372,6 @@ final class VideoScreenModel: ObservableObject {
             coordinator.showToast("이 기기에서는 PIP를 사용할 수 없습니다.")
             return
         }
-        if let previous = pipVideoHolder {
-            previous.evaluate(PlayerWebScripts.shared.playback(command: .pause))
-            previous.dispose()
-            pipVideoHolder = nil
-            pipHost = nil
-        }
         hideController()
         isInPictureInPicture = true
         isPlayerVisible = false
@@ -418,12 +408,6 @@ final class VideoScreenModel: ObservableObject {
         isInPictureInPicture = false
         hideController()
         IosPlayerOrientation.lockPortraitOnPhone()
-        if let previous = pipVideoHolder {
-            previous.evaluate(PlayerWebScripts.shared.playback(command: .pause))
-            previous.dispose()
-            pipVideoHolder = nil
-            pipHost = nil
-        }
         resetToLectureList()
         coordinator.clearActiveVideoModelIfIdle()
     }
@@ -467,12 +451,6 @@ final class VideoScreenModel: ObservableObject {
         isPlayerVisible = false
         hideController()
         IosPlayerOrientation.lockPortraitOnPhone()
-        if let previous = pipVideoHolder {
-            previous.evaluate(PlayerWebScripts.shared.playback(command: .pause))
-            previous.dispose()
-            pipVideoHolder = nil
-            pipHost = nil
-        }
         resetToLectureList()
         coordinator.clearActiveVideoModelIfIdle()
     }
@@ -712,6 +690,12 @@ struct VideoView: View {
             Button("취소", role: .cancel) {}
         } message: {
             Text("정말 강의 수강을 종료할까요?")
+        }
+        .confirmationDialog("강의 전환", isPresented: $model.showLectureChangeConfirm, titleVisibility: .visible) {
+            Button("확인", role: .destructive) { model.confirmLectureChange() }
+            Button("취소", role: .cancel) { model.cancelLectureChange() }
+        } message: {
+            Text("지금 재생 중인 강의를 종료하고 선택한 강의를 재생할까요?")
         }
         .accessibilityIdentifier("video_view")
     }

--- a/iosApp/iosApp/WebSurfaceOverlays.swift
+++ b/iosApp/iosApp/WebSurfaceOverlays.swift
@@ -18,6 +18,26 @@ extension View {
                 holder.confirmJavaScriptAlert()
             }
         }
+        .background {
+            Color.clear
+                .alert(
+                    "안내",
+                    isPresented: Binding(
+                        get: { enabled && holder.javaScriptConfirmMessage != nil },
+                        set: { if !$0 { holder.answerJavaScriptConfirm(false) } }
+                    )
+                ) {
+                    Button("확인") { holder.answerJavaScriptConfirm(true) }
+                    Button("취소", role: .cancel) { holder.answerJavaScriptConfirm(false) }
+                } message: {
+                    Text(holder.javaScriptConfirmMessage ?? "")
+                }
+        }
+        .onReceive(holder.$javaScriptConfirmMessage) { message in
+            if !enabled, message != nil {
+                holder.answerJavaScriptConfirm(false)
+            }
+        }
     }
 
     func webJavaScriptAlert(
@@ -35,6 +55,44 @@ extension View {
     }
 }
 
+enum WebJavaScriptPresentation {
+    static func holder(
+        primary: WebViewHolder,
+        secondary: WebViewHolder,
+        secondaryEnabled: Bool,
+        sticky: WebViewHolder?,
+        keyPath: KeyPath<WebViewHolder, String?>
+    ) -> WebViewHolder? {
+        if let sticky, sticky[keyPath: keyPath] != nil {
+            return sticky
+        }
+        if primary[keyPath: keyPath] != nil {
+            return primary
+        }
+        if secondaryEnabled, secondary[keyPath: keyPath] != nil {
+            return secondary
+        }
+        return nil
+    }
+}
+
+enum WebJavaScriptConfirmPresentation {
+    static func holder(
+        primary: WebViewHolder,
+        secondary: WebViewHolder,
+        secondaryEnabled: Bool,
+        sticky: WebViewHolder?
+    ) -> WebViewHolder? {
+        WebJavaScriptPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: secondaryEnabled,
+            sticky: sticky,
+            keyPath: \.javaScriptConfirmMessage
+        )
+    }
+}
+
 enum WebJavaScriptAlertPresentation {
     static func holder(
         primary: WebViewHolder,
@@ -42,16 +100,13 @@ enum WebJavaScriptAlertPresentation {
         secondaryEnabled: Bool,
         sticky: WebViewHolder?
     ) -> WebViewHolder? {
-        if let sticky, sticky.javaScriptAlertMessage != nil {
-            return sticky
-        }
-        if primary.javaScriptAlertMessage != nil {
-            return primary
-        }
-        if secondaryEnabled, secondary.javaScriptAlertMessage != nil {
-            return secondary
-        }
-        return nil
+        WebJavaScriptPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: secondaryEnabled,
+            sticky: sticky,
+            keyPath: \.javaScriptAlertMessage
+        )
     }
 }
 
@@ -60,6 +115,7 @@ struct WebJavaScriptAlertHost: View {
     @ObservedObject var secondary: WebViewHolder
     var secondaryEnabled: Bool = true
     @State private var presentedHolder: WebViewHolder?
+    @State private var presentedConfirmHolder: WebViewHolder?
 
     var body: some View {
         EmptyView()
@@ -74,6 +130,21 @@ struct WebJavaScriptAlertHost: View {
             } message: {
                 Text(presentedHolder?.javaScriptAlertMessage ?? "")
             }
+            .background {
+                Color.clear
+                    .alert(
+                        "안내",
+                        isPresented: Binding(
+                            get: { presentedConfirmHolder?.javaScriptConfirmMessage != nil },
+                            set: { if !$0 { presentedConfirmHolder?.answerJavaScriptConfirm(false) } }
+                        )
+                    ) {
+                        Button("확인") { presentedConfirmHolder?.answerJavaScriptConfirm(true) }
+                        Button("취소", role: .cancel) { presentedConfirmHolder?.answerJavaScriptConfirm(false) }
+                    } message: {
+                        Text(presentedConfirmHolder?.javaScriptConfirmMessage ?? "")
+                    }
+            }
             .onReceive(primary.$javaScriptAlertMessage) { _ in
                 refreshPresentedHolder()
             }
@@ -84,11 +155,25 @@ struct WebJavaScriptAlertHost: View {
                 }
                 refreshPresentedHolder()
             }
+            .onReceive(primary.$javaScriptConfirmMessage) { _ in
+                refreshPresentedConfirmHolder()
+            }
+            .onReceive(secondary.$javaScriptConfirmMessage) { message in
+                if !secondaryEnabled, message != nil {
+                    secondary.answerJavaScriptConfirm(false)
+                    return
+                }
+                refreshPresentedConfirmHolder()
+            }
             .onChange(of: secondaryEnabled) { enabled in
                 if !enabled, secondary.javaScriptAlertMessage != nil {
                     secondary.confirmJavaScriptAlert()
                 }
+                if !enabled, secondary.javaScriptConfirmMessage != nil {
+                    secondary.answerJavaScriptConfirm(false)
+                }
                 refreshPresentedHolder()
+                refreshPresentedConfirmHolder()
             }
     }
 
@@ -110,5 +195,25 @@ struct WebJavaScriptAlertHost: View {
             return
         }
         presentedHolder = next
+    }
+
+    private func refreshPresentedConfirmHolder() {
+        let next = WebJavaScriptConfirmPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: secondaryEnabled,
+            sticky: presentedConfirmHolder
+        )
+        if presentedConfirmHolder === next {
+            return
+        }
+        if presentedConfirmHolder != nil, next != nil {
+            presentedConfirmHolder = nil
+            DispatchQueue.main.async {
+                refreshPresentedConfirmHolder()
+            }
+            return
+        }
+        presentedConfirmHolder = next
     }
 }

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -8,9 +8,12 @@ final class WebViewHolder: NSObject, ObservableObject {
     let creationID = UUID()
 
     @Published private(set) var isDisposed = false
-    @Published private(set) var navigationState = WebNavigationState()
+    @Published private(set) var navigationState = WebNavigationState() {
+        didSet { onNavigationStateChange?(navigationState) }
+    }
     @Published private(set) var lastExternalURL: String?
     @Published var javaScriptAlertMessage: String?
+    @Published var javaScriptConfirmMessage: String?
     @Published private(set) var downloadProgress: DownloadProgressState?
     @Published private(set) var downloadErrorMessage: String?
     @Published private(set) var shareableFileURL: URL?
@@ -18,6 +21,7 @@ final class WebViewHolder: NSObject, ObservableObject {
     private var _webView: WKWebView?
     private var bridgeAdapter: IosBridgeMessageAdapter?
     private var javaScriptAlertCompletion: (() -> Void)?
+    private var javaScriptConfirmCompletion: ((Bool) -> Void)?
     private lazy var navigationRelay = NavigationRelay(owner: self)
     private lazy var uiRelay = UIRelay(owner: self)
     private let trustedOrigins = TrustedOriginPolicy(trustedOrigins: TrustedOriginPolicy.companion.DEFAULT_TRUSTED_ORIGINS)
@@ -27,9 +31,12 @@ final class WebViewHolder: NSObject, ObservableObject {
     private let filePicker: IosFilePicker
     private let fileTransfer: IosFileTransfer
     private let allowsInAppWeb: Bool
+    private let allowsVideoContentHosts: Bool
     private var activeDownloadTask: Task<Void, Never>?
     private var loadingLocalPdf = false
     private var webContentTerminationRetryUsed = false
+    private var pendingDocumentStartScripts: [WKUserScript] = []
+    var onNavigationStateChange: ((WebNavigationState) -> Void)?
 
     static var websiteDataStore: WKWebsiteDataStore { .default() }
 
@@ -44,12 +51,14 @@ final class WebViewHolder: NSObject, ObservableObject {
         navigator: IosExternalNavigator = IosExternalNavigator.companion.system(),
         filePicker: IosFilePicker = IosFilePicker(),
         fileTransfer: IosFileTransfer = IosFileTransfer(),
-        allowsInAppWeb: Bool = false
+        allowsInAppWeb: Bool = false,
+        allowsVideoContentHosts: Bool = false
     ) {
         self.navigator = navigator
         self.filePicker = filePicker
         self.fileTransfer = fileTransfer
         self.allowsInAppWeb = allowsInAppWeb
+        self.allowsVideoContentHosts = allowsVideoContentHosts
         super.init()
         fileTransfer.onProgress = { [weak self] fileName, fraction in
             self?.downloadProgress = DownloadProgressState(fileName: fileName, fraction: fraction)
@@ -67,6 +76,15 @@ final class WebViewHolder: NSObject, ObservableObject {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = Self.websiteDataStore
         configuration.applicationNameForUserAgent = Self.iosAppUserAgentToken
+        if allowsVideoContentHosts {
+            configuration.allowsInlineMediaPlayback = true
+            configuration.mediaTypesRequiringUserActionForPlayback = []
+            configuration.allowsPictureInPictureMediaPlayback = true
+            configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
+        }
+        for script in pendingDocumentStartScripts {
+            configuration.userContentController.addUserScript(script)
+        }
         configuration.userContentController.addUserScript(
             WKUserScript(
                 source: WebSurfaceViewportScript.source,
@@ -93,6 +111,22 @@ final class WebViewHolder: NSObject, ObservableObject {
         scrollView.keyboardDismissMode = .interactive
     }
 
+    /// WKWebView 생성 전에만 호출. 매 문서 로드 시작 시 localStorage 등을 심는다.
+    func addDocumentStartScript(_ script: WebScript, forMainFrameOnly: Bool = true) {
+        addDocumentStartScriptSource(script.reveal(), forMainFrameOnly: forMainFrameOnly)
+    }
+
+    func addDocumentStartScriptSource(_ source: String, forMainFrameOnly: Bool = true) {
+        precondition(_webView == nil, "document-start script는 WKWebView 생성 전에 설치해야 한다")
+        pendingDocumentStartScripts.append(
+            WKUserScript(
+                source: source,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: forMainFrameOnly
+            )
+        )
+    }
+
     /// WKWebView 생성 전에만 호출
     func installBridge(
         surface: BridgeSurface,
@@ -115,7 +149,10 @@ final class WebViewHolder: NSObject, ObservableObject {
         handler: BridgeCommandHandler,
         synchronousHandler: SynchronousBridgeCommandHandler? = nil
     ) -> WebViewHolder {
-        let holder = WebViewHolder(allowsInAppWeb: surface == .linkView)
+        let holder = WebViewHolder(
+            allowsInAppWeb: surface == .linkView,
+            allowsVideoContentHosts: surface == .video
+        )
         holder.installBridge(
             surface: surface,
             handler: handler,
@@ -129,9 +166,9 @@ final class WebViewHolder: NSObject, ObservableObject {
             completion?(nil)
             return
         }
-        webView.evaluateJavaScript(script.reveal(), completionHandler: { result, _ in
+        webView.evaluateJavaScript(script.reveal()) { result, _ in
             completion?(result)
-        })
+        }
     }
 
     func evaluateRaw(_ source: String, completion: ((Any?) -> Void)? = nil) {
@@ -139,13 +176,15 @@ final class WebViewHolder: NSObject, ObservableObject {
             completion?(nil)
             return
         }
-        webView.evaluateJavaScript(source, completionHandler: { result, _ in
+        webView.evaluateJavaScript(source) { result, _ in
             completion?(result)
-        })
+        }
     }
 
+    var autoDismissJavaScriptAlerts: Bool = false
     var suppressJavaScriptAlertContaining: String?
     var onSuppressedJavaScriptAlert: (() -> Void)?
+    var onJavaScriptAlertReceived: ((String) -> Void)?
     var onWebContentProcessDidTerminate: (() -> Void)?
 
     func confirmJavaScriptAlert() {
@@ -156,6 +195,11 @@ final class WebViewHolder: NSObject, ObservableObject {
     }
 
     func presentJavaScriptAlert(message: String, completion: @escaping () -> Void) {
+        onJavaScriptAlertReceived?(message)
+        if autoDismissJavaScriptAlerts {
+            completion()
+            return
+        }
         if let marker = suppressJavaScriptAlertContaining, message.contains(marker) {
             completion()
             onSuppressedJavaScriptAlert?()
@@ -166,10 +210,32 @@ final class WebViewHolder: NSObject, ObservableObject {
         javaScriptAlertMessage = message
     }
 
+    func presentJavaScriptConfirm(message: String, completion: @escaping (Bool) -> Void) {
+        if autoDismissJavaScriptAlerts {
+            completion(true)
+            return
+        }
+        javaScriptConfirmCompletion?(false)
+        javaScriptConfirmCompletion = completion
+        javaScriptConfirmMessage = message
+    }
+
+    func answerJavaScriptConfirm(_ confirmed: Bool) {
+        let completion = javaScriptConfirmCompletion
+        javaScriptConfirmCompletion = nil
+        javaScriptConfirmMessage = nil
+        completion?(confirmed)
+    }
+
     func load(_ urlString: String) {
         guard !isDisposed, let url = URL(string: urlString) else { return }
+        loadRequest(URLRequest(url: url))
+    }
+
+    func loadRequest(_ request: URLRequest) {
+        guard !isDisposed else { return }
         webContentTerminationRetryUsed = false
-        webView.load(URLRequest(url: url))
+        webView.load(request)
     }
 
     func loadHTML(_ html: String, baseURL: URL) {
@@ -221,14 +287,22 @@ final class WebViewHolder: NSObject, ObservableObject {
     func dispose() {
         guard !isDisposed else { return }
         isDisposed = true
-        webContentTerminationRetryUsed = false
-        suppressJavaScriptAlertContaining = nil
+        activeDownloadTask?.cancel()
+        activeDownloadTask = nil
         onSuppressedJavaScriptAlert = nil
+        onJavaScriptAlertReceived = nil
         onWebContentProcessDidTerminate = nil
+        onNavigationStateChange = nil
         bridgeAdapter?.dispose()
         bridgeAdapter = nil
         cancelDownload()
         clearInlinePdf()
+        javaScriptAlertCompletion?()
+        javaScriptAlertCompletion = nil
+        javaScriptAlertMessage = nil
+        javaScriptConfirmCompletion?(false)
+        javaScriptConfirmCompletion = nil
+        javaScriptConfirmMessage = nil
         guard let view = _webView else {
             navigationState = WebNavigationState(loadPhase: .disposed)
             return
@@ -238,9 +312,6 @@ final class WebViewHolder: NSObject, ObservableObject {
         view.uiDelegate = nil
         view.removeFromSuperview()
         _webView = nil
-        javaScriptAlertCompletion?()
-        javaScriptAlertCompletion = nil
-        javaScriptAlertMessage = nil
         navigationState = WebNavigationState(loadPhase: .disposed)
     }
 
@@ -257,16 +328,25 @@ final class WebViewHolder: NSObject, ObservableObject {
         if isAllowedInAppWeb(urlString) {
             return true
         }
+        if isAllowedVideoContent(urlString) {
+            return true
+        }
 
         openExternal(urlString)
         return false
     }
 
     func handleCreateWindow(urlString: String?) {
+        guard let urlString, !urlString.isEmpty, let url = URL(string: urlString) else { return }
+        handleCreateWindow(request: URLRequest(url: url))
+    }
+
+    func handleCreateWindow(request: URLRequest) {
         guard !isDisposed else { return }
-        guard let urlString, !urlString.isEmpty else { return }
-        if trustedOrigins.isTrustedUrl(url: urlString) || isAllowedInAppWeb(urlString) {
-            load(urlString)
+        let urlString = request.url?.absoluteString ?? ""
+        guard !urlString.isEmpty, urlString != "about:blank" else { return }
+        if trustedOrigins.isTrustedUrl(url: urlString) || isAllowedInAppWeb(urlString) || isAllowedVideoContent(urlString) {
+            loadRequest(request)
         } else {
             openExternal(urlString)
         }
@@ -521,6 +601,11 @@ final class WebViewHolder: NSObject, ObservableObject {
         return klasContentOrigins.isTrustedUrl(url: raw)
     }
 
+    private func isAllowedVideoContent(_ raw: String) -> Bool {
+        guard allowsVideoContentHosts else { return false }
+        return klasContentOrigins.isTrustedVideoUrl(url: raw)
+    }
+
     private func presentShareSheet(url: URL, deleteWhenDone: Bool) {
         guard FileManager.default.fileExists(atPath: url.path) else {
             if deleteWhenDone {
@@ -650,7 +735,7 @@ private final class UIRelay: NSObject, WKUIDelegate {
         for navigationAction: WKNavigationAction,
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
-        owner?.handleCreateWindow(urlString: navigationAction.request.url?.absoluteString)
+        owner?.handleCreateWindow(request: navigationAction.request)
         return nil
     }
 
@@ -663,6 +748,15 @@ private final class UIRelay: NSObject, WKUIDelegate {
         owner?.presentJavaScriptAlert(message: message, completion: completionHandler)
     }
 
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        owner?.presentJavaScriptConfirm(message: message, completion: completionHandler)
+    }
+
     @available(iOS 18.4, *)
     func webView(
         _ webView: WKWebView,
@@ -673,3 +767,4 @@ private final class UIRelay: NSObject, WKUIDelegate {
         owner?.handleOpenPanel(allowMultiple: parameters.allowsMultipleSelection, completionHandler: completionHandler)
     }
 }
+

--- a/iosApp/iosApp/WebViewHolder.swift
+++ b/iosApp/iosApp/WebViewHolder.swift
@@ -182,10 +182,12 @@ final class WebViewHolder: NSObject, ObservableObject {
     }
 
     var autoDismissJavaScriptAlerts: Bool = false
+    var autoDismissJavaScriptConfirms: Bool = false
     var suppressJavaScriptAlertContaining: String?
     var onSuppressedJavaScriptAlert: (() -> Void)?
     var onJavaScriptAlertReceived: ((String) -> Void)?
     var onWebContentProcessDidTerminate: (() -> Void)?
+    var onWindowCloseRequested: (() -> Void)?
 
     func confirmJavaScriptAlert() {
         let completion = javaScriptAlertCompletion
@@ -211,7 +213,7 @@ final class WebViewHolder: NSObject, ObservableObject {
     }
 
     func presentJavaScriptConfirm(message: String, completion: @escaping (Bool) -> Void) {
-        if autoDismissJavaScriptAlerts {
+        if autoDismissJavaScriptConfirms {
             completion(true)
             return
         }
@@ -755,6 +757,10 @@ private final class UIRelay: NSObject, WKUIDelegate {
         completionHandler: @escaping (Bool) -> Void
     ) {
         owner?.presentJavaScriptConfirm(message: message, completion: completionHandler)
+    }
+
+    func webViewDidClose(_ webView: WKWebView) {
+        owner?.onWindowCloseRequested?()
     }
 
     @available(iOS 18.4, *)

--- a/iosApp/iosAppTests/IosFilePortsTests.swift
+++ b/iosApp/iosAppTests/IosFilePortsTests.swift
@@ -88,6 +88,44 @@ final class IosFilePortsTests: XCTestCase {
         let defaultHolder = WebViewHolder()
         defer { defaultHolder.dispose() }
         XCTAssertNil(defaultHolder.pageReadyScript(for: "https://www.kw.ac.kr/ko/life/notice.jsp"))
+        XCTAssertFalse(defaultHolder.webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically)
+    }
+
+    func testVideoHolderAllowsKwSubdomainAndRejectsRootHost() {
+        let opener = RecordingUrlOpener()
+        let holder = WebViewHolder(
+            navigator: IosExternalNavigator(opener: opener),
+            allowsVideoContentHosts: true
+        )
+        holder.installBridge(surface: .video, handler: AcceptingBridgeCommandHandler())
+        defer { holder.dispose() }
+
+        XCTAssertTrue(
+            holder.handleDecidePolicy(
+                urlString: "https://vod.kw.ac.kr/player/content",
+                isMainFrame: true
+            )
+        )
+        XCTAssertNil(holder.lastExternalURL)
+        holder.handleCreateWindow(urlString: "https://vod.kw.ac.kr/embed")
+        XCTAssertTrue(opener.opened.isEmpty)
+
+        XCTAssertFalse(
+            holder.handleDecidePolicy(urlString: "https://kw.ac.kr/", isMainFrame: true)
+        )
+        XCTAssertEqual(holder.lastExternalURL, "https://kw.ac.kr/")
+
+        XCTAssertFalse(
+            holder.handleDecidePolicy(urlString: "https://example.com/video", isMainFrame: true)
+        )
+        XCTAssertEqual(opener.opened, ["https://kw.ac.kr/", "https://example.com/video"])
+        XCTAssertNil(holder.pageReadyScript(for: "https://www.kw.ac.kr/ko/life/notice.jsp"))
+
+        _ = holder.webView
+        XCTAssertTrue(holder.webView.configuration.allowsInlineMediaPlayback)
+        XCTAssertTrue(holder.webView.configuration.allowsPictureInPictureMediaPlayback)
+        XCTAssertTrue(holder.webView.configuration.mediaTypesRequiringUserActionForPlayback.isEmpty)
+        XCTAssertTrue(holder.webView.configuration.preferences.javaScriptCanOpenWindowsAutomatically)
     }
 
     func testWebContentProcessTerminationReloadsOnceThenFails() {

--- a/iosApp/iosAppTests/IosHomeHostTests.swift
+++ b/iosApp/iosAppTests/IosHomeHostTests.swift
@@ -151,6 +151,51 @@ final class IosHomeHostTests: XCTestCase {
         XCTAssertTrue(presented)
     }
 
+    func testJavaScriptConfirmAnswersCompleteHandler() {
+        let holder = WebViewHolder()
+        defer { holder.dispose() }
+
+        var answered: Bool?
+        holder.presentJavaScriptConfirm(message: "수강하시겠습니까?") { answered = $0 }
+        XCTAssertEqual(holder.javaScriptConfirmMessage, "수강하시겠습니까?")
+        holder.answerJavaScriptConfirm(true)
+        XCTAssertEqual(answered, true)
+        XCTAssertNil(holder.javaScriptConfirmMessage)
+
+        holder.presentJavaScriptConfirm(message: "취소 테스트") { answered = $0 }
+        holder.answerJavaScriptConfirm(false)
+        XCTAssertEqual(answered, false)
+        XCTAssertNil(holder.javaScriptConfirmMessage)
+    }
+
+    func testJavaScriptConfirmPresentationIgnoresDisabledSecondary() {
+        let primary = WebViewHolder()
+        let secondary = WebViewHolder()
+        defer {
+            primary.dispose()
+            secondary.dispose()
+        }
+        secondary.presentJavaScriptConfirm(message: "klas") { _ in }
+
+        XCTAssertNil(
+            WebJavaScriptConfirmPresentation.holder(
+                primary: primary,
+                secondary: secondary,
+                secondaryEnabled: false,
+                sticky: nil
+            )
+        )
+
+        primary.presentJavaScriptConfirm(message: "ui") { _ in }
+        let visible = WebJavaScriptConfirmPresentation.holder(
+            primary: primary,
+            secondary: secondary,
+            secondaryEnabled: false,
+            sticky: nil
+        )
+        XCTAssertTrue(visible === primary)
+    }
+
     func testBootstrapLectureErrorMatcher() {
         XCTAssertTrue(LectureScreenModel.isBootstrapLectureError("오류가 발생하였습니다."))
         XCTAssertFalse(LectureScreenModel.isBootstrapLectureError("다른 안내"))

--- a/iosApp/iosAppTests/IosVideoHostTests.swift
+++ b/iosApp/iosAppTests/IosVideoHostTests.swift
@@ -200,6 +200,105 @@ final class IosVideoHostTests: XCTestCase {
         XCTAssertEqual(coordinator.toastMessage, "강의를 불러오는 중 오류가 발생했습니다.")
     }
 
+    func testRequestOnlineLectureSuccessShowsKlasAndEvaluatesScript() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+
+        let sampleJson = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M01",
+            "lesson": "L01",
+            "oid": "O01",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 1,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 50,
+            "playtime": "0"
+        }
+        """
+        model.requestOnlineLecture(json: sampleJson)
+        XCTAssertTrue(model.showingKlas)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertNotNil(model.lastKlasScriptSource)
+        XCTAssertTrue(model.lastKlasScriptSource?.contains("lrnCerti.checkCerti") == true || model.lastKlasScriptSource?.contains("appModule.goViewCntnts") == true)
+    }
+
+    func testCertificationSuccessAlertTriggersDirectViewerScript() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+
+        let sampleJson = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M01",
+            "lesson": "L01",
+            "oid": "O01",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 1,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 50,
+            "playtime": "0"
+        }
+        """
+        model.requestOnlineLecture(json: sampleJson)
+        XCTAssertTrue(model.lastKlasScriptSource?.contains("lrnCerti.checkCerti") == true)
+
+        // 본인인증 성공 Alert 발생 시뮬레이션
+        model.klasHolder.presentJavaScriptAlert(message: "인증 되었습니다.", completion: {})
+        XCTAssertTrue(model.lastKlasScriptSource?.contains("appModule.goViewCntnts") == true)
+    }
+
     func testOpenInKlasHidesPlayer() {
         let coordinator = makeCoordinator()
         defer { coordinator.dispose() }
@@ -312,7 +411,7 @@ final class IosVideoHostTests: XCTestCase {
         )
         XCTAssertTrue(completionCalled)
         XCTAssertEqual(
-            model.alertMessage,
+            coordinator.toastMessage,
             "학습기간이 아닙니다. 학습 시작일 이후에 학습이 가능합니다."
         )
     }
@@ -334,7 +433,7 @@ final class IosVideoHostTests: XCTestCase {
         )
         XCTAssertTrue(completionCalled)
         XCTAssertEqual(
-            model.alertMessage,
+            coordinator.toastMessage,
             "학습 시작일 이전에 강의 영상을 미리 시청할 수 있습니다."
         )
     }
@@ -468,7 +567,7 @@ final class IosVideoHostTests: XCTestCase {
         XCTAssertNotNil(coordinator.activeVideoModel)
     }
 
-    func testPipCloseWithXButtonCleansUpWithoutNavigatingToVideo() {
+    func testConfirmCloseCleansUpActiveVideoModel() {
         let coordinator = makeCoordinator()
         defer { coordinator.dispose() }
         coordinator.handleBootstrap(Self.readyHomeResult())
@@ -477,13 +576,33 @@ final class IosVideoHostTests: XCTestCase {
         model.isInPictureInPicture = true
         coordinator.isVideoScreenPresented = false
 
-        // When closed with X (isClosed: true)
-        model.restorePlayerAfterPictureInPicture(isClosed: true)
+        model.confirmClose()
 
         XCTAssertFalse(model.isInPictureInPicture)
         XCTAssertFalse(model.isPlayerVisible)
         XCTAssertNil(coordinator.activeVideoModel)
         XCTAssertEqual(coordinator.path.count, 0)
+    }
+
+    func testOpenOnlineLectureListCleansUpIdleActiveVideoModel() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.isInPictureInPicture = false
+        coordinator.isVideoScreenPresented = false
+
+        // When navigating to online lecture list while idle
+        coordinator.openOnlineLectureList(subjectId: "SUBJ01", yearSemester: "2026,1")
+
+        // 1. Previous active model should be cleaned up (nil)
+        XCTAssertNil(coordinator.activeVideoModel)
+        XCTAssertEqual(coordinator.path.count, 1)
+
+        // 2. When VideoView creates a new model, it should start in clean list mode
+        let cleanModel = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        XCTAssertFalse(cleanModel.isPlayerVisible)
     }
 
     private func makeCoordinator() -> HomeCoordinator {

--- a/iosApp/iosAppTests/IosVideoHostTests.swift
+++ b/iosApp/iosAppTests/IosVideoHostTests.swift
@@ -577,6 +577,18 @@ final class IosVideoHostTests: XCTestCase {
         XCTAssertNil(coordinator.activeVideoModel)
     }
 
+    func testPiPRestoreTrackerMarksAndResetsRequestedState() {
+        let tracker = PiPRestoreTracker.shared
+        tracker.reset()
+        XCTAssertFalse(tracker.isRestoreRequested)
+
+        tracker.markRestoreRequested()
+        XCTAssertTrue(tracker.isRestoreRequested)
+
+        tracker.reset()
+        XCTAssertFalse(tracker.isRestoreRequested)
+    }
+
     func testOpenOnlineLectureListCleansUpIdleActiveVideoModel() {
         let coordinator = makeCoordinator()
         defer { coordinator.dispose() }

--- a/iosApp/iosAppTests/IosVideoHostTests.swift
+++ b/iosApp/iosAppTests/IosVideoHostTests.swift
@@ -649,7 +649,7 @@ final class IosVideoHostTests: XCTestCase {
         XCTAssertFalse(model.showingKlas)
     }
 
-    func testRequestOnlineLectureDifferentLectureWhileInPipResetsPreviousSession() {
+    func testRequestOnlineLectureDifferentLectureWhileInPipShowsConfirmDialog() {
         let coordinator = makeCoordinator()
         defer { coordinator.dispose() }
         coordinator.handleBootstrap(Self.readyHomeResult())
@@ -720,30 +720,98 @@ final class IosVideoHostTests: XCTestCase {
         model.onDismissRequested = { autoDismissed = true }
         coordinator.isVideoScreenPresented = true
 
-        let previousHolder = model.videoHolder
         model.requestOnlineLecture(json: lecture2)
 
-        // Plan A: previous videoHolder is retained as pipVideoHolder, and new videoHolder is created
-        XCTAssertNotNil(model.pipVideoHolder)
-        XCTAssertTrue(model.pipVideoHolder === previousHolder)
-        XCTAssertFalse(model.videoHolder === previousHolder)
+        // 확인 다이얼로그가 표시되고, PiP는 아직 유지
+        XCTAssertTrue(model.showLectureChangeConfirm)
+        XCTAssertTrue(model.isInPictureInPicture)
+        XCTAssertFalse(model.showingKlas)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertFalse(autoDismissed)
+
+        // 확인 시 PiP 종료 후 새 강의 로드
+        model.confirmLectureChange()
+        XCTAssertFalse(model.showLectureChangeConfirm)
         XCTAssertFalse(model.isInPictureInPicture)
-        XCTAssertTrue(model.hasActivePip)
         XCTAssertTrue(model.showingKlas)
         XCTAssertFalse(model.isPlayerVisible)
-        XCTAssertFalse(autoDismissed, "VideoView should NOT auto-dismiss when selecting a different lecture!")
+    }
 
-        // When new video URL arrives, it displays in the player overlay on the main screen
-        model.receiveVideoURL("https://vod.kw.ac.kr/player2")
-        XCTAssertTrue(model.isPlayerVisible)
-        XCTAssertFalse(model.showingKlas)
-        XCTAssertTrue(model.hasActivePip)
+    func testRequestOnlineLectureDifferentLectureWhileInPipCancelKeepsPip() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
 
-        // When starting PiP on the new video, the previous PiP holder is cleanly disposed
+        let lecture1 = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M01",
+            "lesson": "L01",
+            "oid": "O01",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 1,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 50,
+            "playtime": "0"
+        }
+        """
+        model.requestOnlineLecture(json: lecture1)
+        model.receiveVideoURL("https://vod.kw.ac.kr/player1")
         model.startPictureInPicture()
-        XCTAssertNil(model.pipVideoHolder)
         XCTAssertTrue(model.isInPictureInPicture)
-        XCTAssertFalse(model.isPlayerVisible)
+
+        let lecture2 = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M02",
+            "lesson": "L02",
+            "oid": "O02",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 2,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 0,
+            "playtime": "0"
+        }
+        """
+        model.requestOnlineLecture(json: lecture2)
+        XCTAssertTrue(model.showLectureChangeConfirm)
+
+        // 취소 시 PiP 유지
+        model.cancelLectureChange()
+        XCTAssertFalse(model.showLectureChangeConfirm)
+        XCTAssertTrue(model.isInPictureInPicture)
+        XCTAssertFalse(model.showingKlas)
     }
 
     func testRequestOnlineLectureWhileOnViewerPageQueuesScriptAndExecutesOnListReady() {

--- a/iosApp/iosAppTests/IosVideoHostTests.swift
+++ b/iosApp/iosAppTests/IosVideoHostTests.swift
@@ -86,10 +86,18 @@ final class IosVideoHostTests: XCTestCase {
         model.move(.forward)
         XCTAssertTrue(model.lastVideoScriptSource?.contains("_seekLimit") == true)
 
+        XCTAssertTrue(model.uiState.isMuted)
         model.toggleMute()
+        XCTAssertFalse(model.uiState.isMuted)
         XCTAssertEqual(
             model.lastVideoScriptSource,
             PlayerWebScripts.shared.mute(muted: false).reveal()
+        )
+        model.toggleMute()
+        XCTAssertTrue(model.uiState.isMuted)
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.mute(muted: true).reveal()
         )
 
         model.selectSpeed(1.5)
@@ -375,14 +383,10 @@ final class IosVideoHostTests: XCTestCase {
         let coordinator = makeCoordinator()
         defer { coordinator.dispose() }
         coordinator.handleBootstrap(Self.readyHomeResult())
-        let model = VideoScreenModel(
-            subjectId: "SUBJ01",
-            yearSemester: "2026,1",
-            sessionToken: coordinator.sessionToken,
-            coordinator: coordinator
-        )
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
         model.receiveVideoURL("https://vod.kw.ac.kr/player")
         model.showCloseConfirm = true
+        coordinator.isVideoScreenPresented = false
         XCTAssertTrue(model.isPlayerVisible)
 
         model.confirmClose()
@@ -392,6 +396,7 @@ final class IosVideoHostTests: XCTestCase {
             model.lastVideoScriptSource,
             PlayerWebScripts.shared.playback(command: .pause).reveal()
         )
+        XCTAssertNil(coordinator.activeVideoModel)
     }
 
     func testKlasHolderJavaScriptAlertPresentsNativeAlertNonBlockingly() {
@@ -435,53 +440,6 @@ final class IosVideoHostTests: XCTestCase {
         XCTAssertEqual(
             coordinator.toastMessage,
             "학습 시작일 이전에 강의 영상을 미리 시청할 수 있습니다."
-        )
-    }
-
-    func testToggleMuteTogglesStateAndEvaluatesScript() {
-        let coordinator = makeCoordinator()
-        defer { coordinator.dispose() }
-        coordinator.handleBootstrap(Self.readyHomeResult())
-        let model = VideoScreenModel(
-            subjectId: "SUBJ01",
-            yearSemester: "2026,1",
-            sessionToken: coordinator.sessionToken,
-            coordinator: coordinator
-        )
-        model.receiveVideoURL("https://vod.kw.ac.kr/player")
-        XCTAssertFalse(model.uiState.isMuted)
-
-        model.toggleMute()
-        XCTAssertTrue(model.uiState.isMuted)
-        XCTAssertEqual(
-            model.lastVideoScriptSource,
-            PlayerWebScripts.shared.mute(muted: true).reveal()
-        )
-
-        model.toggleMute()
-        XCTAssertFalse(model.uiState.isMuted)
-        XCTAssertEqual(
-            model.lastVideoScriptSource,
-            PlayerWebScripts.shared.mute(muted: false).reveal()
-        )
-    }
-
-    func testStartPictureInPictureExecutesEnterPipScriptDirectlyWithoutForcingFullscreen() {
-        let coordinator = makeCoordinator()
-        defer { coordinator.dispose() }
-        coordinator.handleBootstrap(Self.readyHomeResult())
-        let model = VideoScreenModel(
-            subjectId: "SUBJ01",
-            yearSemester: "2026,1",
-            sessionToken: coordinator.sessionToken,
-            coordinator: coordinator
-        )
-        model.receiveVideoURL("https://vod.kw.ac.kr/player")
-        model.startPictureInPicture()
-
-        XCTAssertEqual(
-            model.lastVideoScriptSource,
-            PlayerWebScripts.shared.enterPictureInPicture().reveal()
         )
     }
 
@@ -582,6 +540,10 @@ final class IosVideoHostTests: XCTestCase {
 
         XCTAssertTrue(model.isInPictureInPicture)
         XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.enterPictureInPicture().reveal()
+        )
 
         // Simulate restore while user is outside video screen (isVideoScreenPresented = false)
         coordinator.isVideoScreenPresented = false
@@ -596,31 +558,6 @@ final class IosVideoHostTests: XCTestCase {
             }
         }
         wait(for: [expectation], timeout: 1.0)
-    }
-
-    func testNativePipEntryAutoDismissesVideoViewAndPreservesSession() {
-        let coordinator = makeCoordinator()
-        defer { coordinator.dispose() }
-        coordinator.handleBootstrap(Self.readyHomeResult())
-        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
-        model.receiveVideoURL("https://vod.kw.ac.kr/player")
-        coordinator.isVideoScreenPresented = true
-
-        var dismissed = false
-        model.onDismissRequested = { dismissed = true }
-
-        // Simulate entering PIP via native fullscreen controls
-        model.isInPictureInPicture = false
-        model.refreshPictureInPictureMode()
-
-        // handleBack when in PIP should not destroy player
-        model.isInPictureInPicture = true
-        model.isPlayerVisible = false
-        var backDismissed = false
-        model.handleBack(dismiss: { backDismissed = true })
-        XCTAssertTrue(backDismissed)
-        XCTAssertFalse(model.isPlayerVisible)
-        XCTAssertNotNil(coordinator.activeVideoModel)
     }
 
     func testSystemPipCloseDismissesPlaybackAndCleansUp() {
@@ -638,23 +575,6 @@ final class IosVideoHostTests: XCTestCase {
         XCTAssertFalse(model.isInPictureInPicture)
         XCTAssertFalse(model.isPlayerVisible)
         XCTAssertNil(coordinator.activeVideoModel)
-    }
-
-    func testConfirmCloseCleansUpActiveVideoModel() {
-        let coordinator = makeCoordinator()
-        defer { coordinator.dispose() }
-        coordinator.handleBootstrap(Self.readyHomeResult())
-        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
-        model.receiveVideoURL("https://vod.kw.ac.kr/player")
-        model.isInPictureInPicture = true
-        coordinator.isVideoScreenPresented = false
-
-        model.confirmClose()
-
-        XCTAssertFalse(model.isInPictureInPicture)
-        XCTAssertFalse(model.isPlayerVisible)
-        XCTAssertNil(coordinator.activeVideoModel)
-        XCTAssertEqual(coordinator.path.count, 0)
     }
 
     func testOpenOnlineLectureListCleansUpIdleActiveVideoModel() {

--- a/iosApp/iosAppTests/IosVideoHostTests.swift
+++ b/iosApp/iosAppTests/IosVideoHostTests.swift
@@ -1,0 +1,509 @@
+import Foundation
+import Shared
+import XCTest
+@testable import kw_klas_plus
+
+@MainActor
+final class IosVideoHostTests: XCTestCase {
+    func testOpenVideoPushesDestinationWhenSessionExists() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.openVideo(subjectId: "SUBJ01", yearSemester: "2026,1")
+        XCTAssertEqual(coordinator.path.count, 1)
+        XCTAssertNil(coordinator.toastMessage)
+    }
+
+    func testOpenVideoWithoutSessionDoesNotPush() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.openVideo(subjectId: "SUBJ01", yearSemester: "2026,1")
+        XCTAssertEqual(coordinator.path.count, 0)
+    }
+
+    func testOpenTaskOnlineContentsOpensVideo() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        coordinator.openTask(
+            path: "/std/lis/evltn/OnlineCntntsStdPage.do",
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1"
+        )
+        XCTAssertEqual(coordinator.path.count, 1)
+        XCTAssertNil(coordinator.toastMessage)
+    }
+
+    func testUntrustedVideoUrlShowsToastAndKeepsList() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+
+        model.receiveVideoURL("https://evil.example/player")
+        XCTAssertEqual(coordinator.toastMessage, "강의 영상 주소를 확인하지 못했습니다.")
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertFalse(model.showingKlas)
+    }
+
+    func testReceivePlayerStatesAndControlsEvaluatePlayerScripts() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+
+        model.receivePlayerStates(
+            currentTime: "15",
+            duration: "100",
+            isMuted: "true",
+            isPlaying: "true",
+            isFullscreen: "false"
+        )
+        XCTAssertEqual(model.uiState.currentTime, "00:15")
+        XCTAssertEqual(model.uiState.totalTime, "01:40")
+        XCTAssertEqual(model.uiState.progress, 0.15, accuracy: 0.001)
+        XCTAssertTrue(model.uiState.isPlaying)
+        XCTAssertTrue(model.uiState.isMuted)
+
+        model.playPause()
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.playback(command: .pause).reveal()
+        )
+
+        model.move(.forward)
+        XCTAssertTrue(model.lastVideoScriptSource?.contains("_seekLimit") == true)
+
+        model.toggleMute()
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.mute(muted: false).reveal()
+        )
+
+        model.selectSpeed(1.5)
+        XCTAssertEqual(model.uiState.speedText, "1.5x")
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.changePlaybackRate(speed: 1.5).reveal()
+        )
+
+        model.seekToProgress(0.5)
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.seekTo(seconds: 50).reveal()
+        )
+    }
+
+    func testRequestOnlineLectureBeforeKlasLoadedShowsToast() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+
+        XCTAssertFalse(model.didStart)
+        model.requestOnlineLecture(json: "{}")
+        XCTAssertEqual(
+            coordinator.toastMessage,
+            "아직 강의 정보를 불러오는 중이에요. 몇 초 후에 다시 시도해주세요."
+        )
+        XCTAssertFalse(model.showingKlas)
+    }
+
+    func testStartLoadsOnceAndInstallsKlasLocalStorageUserScript() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        defer {
+            model.listHolder.dispose()
+            model.klasHolder.dispose()
+            model.videoHolder.dispose()
+        }
+
+        XCTAssertFalse(model.didStart)
+        let sources = model.klasHolder.webView.configuration.userContentController.userScripts.map(\.source)
+        XCTAssertTrue(sources.contains(where: { $0.contains("selectYearhakgi") }))
+        XCTAssertTrue(sources.contains(where: { $0.contains("selectSubj") }))
+        XCTAssertTrue(sources.contains(where: { $0.contains("window.open") || $0.contains("w.open") }))
+        XCTAssertTrue(sources.contains(where: { $0.contains("SUBJ01") }))
+        XCTAssertTrue(sources.contains(where: { $0.contains("2026,1") }))
+
+        model.start()
+        XCTAssertTrue(model.didStart)
+        model.start()
+        XCTAssertTrue(model.didStart)
+    }
+
+    func testKlasNavigationCallbackAppliesReadyWithoutViewSubscription() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+
+        model.klasHolder.onNavigationStateChange?(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        model.klasHolder.onNavigationStateChange?(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+
+        model.requestOnlineLecture(json: "not-json")
+        XCTAssertEqual(coordinator.toastMessage, "강의를 불러오는 중 오류가 발생했습니다.")
+        XCTAssertFalse(model.showingKlas)
+    }
+
+    func testMalformedOnlineLectureShowsErrorToast() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+
+        model.requestOnlineLecture(json: "not-json")
+        XCTAssertEqual(coordinator.toastMessage, "강의를 불러오는 중 오류가 발생했습니다.")
+    }
+
+    func testOpenInKlasHidesPlayer() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        XCTAssertTrue(model.isPlayerVisible)
+
+        model.openInKLAS()
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertTrue(model.showingKlas)
+    }
+
+    func testReceiveInitSpeedAndLectureProgress() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+
+        model.receiveInitSpeed(currentSpeed: "1.25")
+        XCTAssertEqual(model.uiState.speedText, "1.25x")
+        model.receiveInitSpeed(currentSpeed: "")
+        XCTAssertEqual(model.uiState.speedText, "1.0x")
+
+        model.receiveVideoData(
+            progress: "<span>진도 40%</span>",
+            time: "<span>학습시간 3 분</span>"
+        )
+        XCTAssertTrue(model.uiState.lectureTime.contains("3"))
+        model.seekToLastPlaytime()
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.seekTo(seconds: 180).reveal()
+        )
+    }
+
+    func testViewerBackReturnsToListAndSecondBackDismisses() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        XCTAssertTrue(model.isPlayerVisible)
+
+        var dismissed = false
+        model.handleBack(dismiss: { dismissed = true })
+        XCTAssertFalse(dismissed)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.playback(command: .pause).reveal()
+        )
+
+        model.handleBack(dismiss: { dismissed = true })
+        XCTAssertTrue(dismissed)
+    }
+
+    func testConfirmCloseResetsStateAndHidesPlayer() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.showCloseConfirm = true
+        XCTAssertTrue(model.isPlayerVisible)
+
+        model.confirmClose()
+        XCTAssertFalse(model.showCloseConfirm)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.playback(command: .pause).reveal()
+        )
+    }
+
+    func testKlasHolderJavaScriptAlertPresentsNativeAlertNonBlockingly() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        var completionCalled = false
+        model.klasHolder.presentJavaScriptAlert(
+            message: "학습기간이 아닙니다. 학습 시작일 이후에 학습이 가능합니다.",
+            completion: { completionCalled = true }
+        )
+        XCTAssertTrue(completionCalled)
+        XCTAssertEqual(
+            model.alertMessage,
+            "학습기간이 아닙니다. 학습 시작일 이후에 학습이 가능합니다."
+        )
+    }
+
+    func testListHolderJavaScriptAlertPresentsNativeAlertNonBlockingly() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        var completionCalled = false
+        model.listHolder.presentJavaScriptAlert(
+            message: "학습 시작일 이전에 강의 영상을 미리 시청할 수 있습니다.",
+            completion: { completionCalled = true }
+        )
+        XCTAssertTrue(completionCalled)
+        XCTAssertEqual(
+            model.alertMessage,
+            "학습 시작일 이전에 강의 영상을 미리 시청할 수 있습니다."
+        )
+    }
+
+    func testToggleMuteTogglesStateAndEvaluatesScript() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        XCTAssertFalse(model.uiState.isMuted)
+
+        model.toggleMute()
+        XCTAssertTrue(model.uiState.isMuted)
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.mute(muted: true).reveal()
+        )
+
+        model.toggleMute()
+        XCTAssertFalse(model.uiState.isMuted)
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.mute(muted: false).reveal()
+        )
+    }
+
+    func testStartPictureInPictureExecutesEnterPipScriptDirectlyWithoutForcingFullscreen() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.startPictureInPicture()
+
+        XCTAssertEqual(
+            model.lastVideoScriptSource,
+            PlayerWebScripts.shared.enterPictureInPicture().reveal()
+        )
+    }
+
+    func testHandleBackDuringPictureInPictureDismissesWithoutDestroyingSession() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.isInPictureInPicture = true
+
+        var dismissed = false
+        model.handleBack(dismiss: { dismissed = true })
+
+        XCTAssertTrue(dismissed)
+        XCTAssertTrue(model.isPlayerVisible)
+        XCTAssertEqual(coordinator.activeVideoModel?.subjectId, "SUBJ01")
+    }
+
+    func testCoordinatorPreservesAndReusesActiveVideoModel() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model1 = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        let model2 = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        XCTAssertTrue(model1 === model2)
+
+        model1.isInPictureInPicture = true
+        coordinator.clearActiveVideoModelIfIdle()
+        XCTAssertNotNil(coordinator.activeVideoModel)
+
+        model1.isInPictureInPicture = false
+        coordinator.clearActiveVideoModelIfIdle()
+        XCTAssertNil(coordinator.activeVideoModel)
+    }
+
+    func testStartPictureInPictureInvokesDismissAndRestorePipNavigatesToVideo() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+
+        var dismissed = false
+        model.startPictureInPicture(dismiss: { dismissed = true })
+
+        XCTAssertTrue(model.isInPictureInPicture)
+
+        // Simulate restore while user is outside video screen (isVideoScreenPresented = false)
+        coordinator.isVideoScreenPresented = false
+        model.restorePlayerAfterPictureInPicture()
+
+        let expectation = expectation(description: "Restore navigates to video")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            if coordinator.path.count > 0 {
+                expectation.fulfill()
+            }
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    func testNativePipEntryAutoDismissesVideoViewAndPreservesSession() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        coordinator.isVideoScreenPresented = true
+
+        var dismissed = false
+        model.onDismissRequested = { dismissed = true }
+
+        // Simulate entering PIP via native fullscreen controls
+        model.isInPictureInPicture = false
+        model.refreshPictureInPictureMode()
+
+        // handleBack when in PIP should not destroy player
+        model.isInPictureInPicture = true
+        var backDismissed = false
+        model.handleBack(dismiss: { backDismissed = true })
+        XCTAssertTrue(backDismissed)
+        XCTAssertTrue(model.isPlayerVisible)
+        XCTAssertNotNil(coordinator.activeVideoModel)
+    }
+
+    func testPipCloseWithXButtonCleansUpWithoutNavigatingToVideo() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.isInPictureInPicture = true
+        coordinator.isVideoScreenPresented = false
+
+        // When closed with X (isClosed: true)
+        model.restorePlayerAfterPictureInPicture(isClosed: true)
+
+        XCTAssertFalse(model.isInPictureInPicture)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertNil(coordinator.activeVideoModel)
+        XCTAssertEqual(coordinator.path.count, 0)
+    }
+
+    private func makeCoordinator() -> HomeCoordinator {
+        let suite = "com.icecream.kwklasplus.test.video.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return HomeCoordinator(
+            authRuntime: IosAuthRuntime.companion.create(defaults: defaults),
+            onLogout: {}
+        )
+    }
+
+    private static func readyHomeResult() -> HomeBootstrapResultReady {
+        HomeBootstrapResultReady(
+            sessionToken: SecretValue.companion.of(value: "session"),
+            yearHakgi: "2026,1",
+            yearHakgiListJoined: "2026,1",
+            timetableJson: "{}",
+            deadlineJson: "[]",
+            promptYearHakgiChange: false
+        )
+    }
+}

--- a/iosApp/iosAppTests/IosVideoHostTests.swift
+++ b/iosApp/iosAppTests/IosVideoHostTests.swift
@@ -492,13 +492,65 @@ final class IosVideoHostTests: XCTestCase {
         let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
         model.receiveVideoURL("https://vod.kw.ac.kr/player")
         model.isInPictureInPicture = true
+        model.isPlayerVisible = false
 
         var dismissed = false
         model.handleBack(dismiss: { dismissed = true })
 
         XCTAssertTrue(dismissed)
-        XCTAssertTrue(model.isPlayerVisible)
+        XCTAssertFalse(model.isPlayerVisible)
         XCTAssertEqual(coordinator.activeVideoModel?.subjectId, "SUBJ01")
+    }
+
+    func testHandleBackFromPlayerDuringPictureInPictureReturnsToListFirst() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.isInPictureInPicture = true
+        model.isPlayerVisible = true
+
+        var dismissed = false
+        model.handleBack(dismiss: { dismissed = true })
+
+        XCTAssertFalse(dismissed)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertTrue(model.isInPictureInPicture)
+
+        model.handleBack(dismiss: { dismissed = true })
+        XCTAssertTrue(dismissed)
+    }
+
+    func testShowPlayerFromPipSwitchesToPlayerOverlay() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.startPictureInPicture()
+        XCTAssertTrue(model.isInPictureInPicture)
+        XCTAssertFalse(model.isPlayerVisible)
+
+        model.showPlayerFromPip()
+        XCTAssertTrue(model.isPlayerVisible)
+        XCTAssertFalse(model.showingKlas)
+    }
+
+    func testOpenOnlineLectureListDuringPictureInPictureGuaranteesListVisibility() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.isInPictureInPicture = true
+        model.isPlayerVisible = true
+
+        coordinator.openOnlineLectureList(subjectId: "SUBJ01", yearSemester: "2026,1")
+
+        XCTAssertNotNil(coordinator.activeVideoModel)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertTrue(model.isInPictureInPicture)
     }
 
     func testCoordinatorPreservesAndReusesActiveVideoModel() {
@@ -529,10 +581,13 @@ final class IosVideoHostTests: XCTestCase {
         model.startPictureInPicture(dismiss: { dismissed = true })
 
         XCTAssertTrue(model.isInPictureInPicture)
+        XCTAssertFalse(model.isPlayerVisible)
 
         // Simulate restore while user is outside video screen (isVideoScreenPresented = false)
         coordinator.isVideoScreenPresented = false
         model.restorePlayerAfterPictureInPicture()
+        XCTAssertFalse(model.isInPictureInPicture)
+        XCTAssertTrue(model.isPlayerVisible)
 
         let expectation = expectation(description: "Restore navigates to video")
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
@@ -560,11 +615,29 @@ final class IosVideoHostTests: XCTestCase {
 
         // handleBack when in PIP should not destroy player
         model.isInPictureInPicture = true
+        model.isPlayerVisible = false
         var backDismissed = false
         model.handleBack(dismiss: { backDismissed = true })
         XCTAssertTrue(backDismissed)
-        XCTAssertTrue(model.isPlayerVisible)
+        XCTAssertFalse(model.isPlayerVisible)
         XCTAssertNotNil(coordinator.activeVideoModel)
+    }
+
+    func testSystemPipCloseDismissesPlaybackAndCleansUp() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.startPictureInPicture()
+        XCTAssertTrue(model.isInPictureInPicture)
+
+        // When system PiP close (X button) is detected:
+        model.handlePictureInPictureClosedBySystem()
+
+        XCTAssertFalse(model.isInPictureInPicture)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertNil(coordinator.activeVideoModel)
     }
 
     func testConfirmCloseCleansUpActiveVideoModel() {
@@ -603,6 +676,204 @@ final class IosVideoHostTests: XCTestCase {
         // 2. When VideoView creates a new model, it should start in clean list mode
         let cleanModel = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
         XCTAssertFalse(cleanModel.isPlayerVisible)
+    }
+
+    func testRequestOnlineLectureSameLectureWhileInPipSwitchesToPlayerDirectly() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+
+        let sampleJson = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M01",
+            "lesson": "L01",
+            "oid": "O01",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 1,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 50,
+            "playtime": "0"
+        }
+        """
+        model.requestOnlineLecture(json: sampleJson)
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        model.startPictureInPicture()
+        XCTAssertTrue(model.isInPictureInPicture)
+        XCTAssertFalse(model.isPlayerVisible)
+
+        // Requesting the exact same lecture while in PiP
+        model.requestOnlineLecture(json: sampleJson)
+
+        // Should switch directly to player without showing raw klas view
+        XCTAssertTrue(model.isPlayerVisible)
+        XCTAssertFalse(model.showingKlas)
+    }
+
+    func testRequestOnlineLectureDifferentLectureWhileInPipResetsPreviousSession() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+
+        let lecture1 = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M01",
+            "lesson": "L01",
+            "oid": "O01",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 1,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 50,
+            "playtime": "0"
+        }
+        """
+        model.requestOnlineLecture(json: lecture1)
+        model.receiveVideoURL("https://vod.kw.ac.kr/player1")
+        model.startPictureInPicture()
+        XCTAssertTrue(model.isInPictureInPicture)
+
+        let lecture2 = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M02",
+            "lesson": "L02",
+            "oid": "O02",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 2,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 0,
+            "playtime": "0"
+        }
+        """
+        var autoDismissed = false
+        model.onDismissRequested = { autoDismissed = true }
+        coordinator.isVideoScreenPresented = true
+
+        let previousHolder = model.videoHolder
+        model.requestOnlineLecture(json: lecture2)
+
+        // Plan A: previous videoHolder is retained as pipVideoHolder, and new videoHolder is created
+        XCTAssertNotNil(model.pipVideoHolder)
+        XCTAssertTrue(model.pipVideoHolder === previousHolder)
+        XCTAssertFalse(model.videoHolder === previousHolder)
+        XCTAssertFalse(model.isInPictureInPicture)
+        XCTAssertTrue(model.hasActivePip)
+        XCTAssertTrue(model.showingKlas)
+        XCTAssertFalse(model.isPlayerVisible)
+        XCTAssertFalse(autoDismissed, "VideoView should NOT auto-dismiss when selecting a different lecture!")
+
+        // When new video URL arrives, it displays in the player overlay on the main screen
+        model.receiveVideoURL("https://vod.kw.ac.kr/player2")
+        XCTAssertTrue(model.isPlayerVisible)
+        XCTAssertFalse(model.showingKlas)
+        XCTAssertTrue(model.hasActivePip)
+
+        // When starting PiP on the new video, the previous PiP holder is cleanly disposed
+        model.startPictureInPicture()
+        XCTAssertNil(model.pipVideoHolder)
+        XCTAssertTrue(model.isInPictureInPicture)
+        XCTAssertFalse(model.isPlayerVisible)
+    }
+
+    func testRequestOnlineLectureWhileOnViewerPageQueuesScriptAndExecutesOnListReady() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = coordinator.videoModel(subjectId: "SUBJ01", yearSemester: "2026,1")
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        // Simulate navigation to viewer page for lecture 1
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/spv/lis/lctre/viewer/LctreCntntsViewSpvPage.do"))
+        )
+
+        let sampleJson = """
+        {
+            "grcode": "GR01",
+            "subj": "SUBJ01",
+            "year": "2026",
+            "hakgi": "1",
+            "bunban": "01",
+            "module": "M01",
+            "lesson": "L01",
+            "oid": "O01",
+            "starting": "0",
+            "contentsType": "mp4",
+            "weeklyseq": 1,
+            "weeklysubseq": 1,
+            "width": 1280,
+            "height": 720,
+            "today": "20260902",
+            "startdate": "20260901",
+            "enddate": "20260908",
+            "ptype": "1",
+            "lrntime": "60",
+            "prog": 100,
+            "playtime": "0"
+        }
+        """
+        model.requestOnlineLecture(json: sampleJson)
+        // Script should be queued, not executed on viewer page
+        XCTAssertFalse(model.lastKlasScriptSource?.contains("appModule.goViewCntnts") ?? false)
+
+        // When OnlineCntntsStdPage.do finishes loading, pending script executes
+        model.handleKlasNavigation(
+            WebNavigationState(loadPhase: .ready(url: "https://klas.kw.ac.kr/std/lis/evltn/OnlineCntntsStdPage.do"))
+        )
+        XCTAssertNotNil(model.lastKlasScriptSource)
+        XCTAssertTrue(model.lastKlasScriptSource!.contains("appModule.goViewCntnts"))
     }
 
     private func makeCoordinator() -> HomeCoordinator {

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/bridge/BridgeValidator.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/bridge/BridgeValidator.kt
@@ -30,18 +30,28 @@ class TrustedOriginPolicy(
 
 class KlasContentOriginPolicy {
     fun isTrustedUrl(url: String): Boolean {
-        if (url.isBlank() || url != url.trim() || url.any(Char::isISOControl)) return false
+        val authority = httpsAuthority(url) ?: return false
+        return authority == ROOT_HOST || authority.endsWith(".$ROOT_HOST")
+    }
+
+    fun isTrustedVideoUrl(url: String): Boolean {
+        val authority = httpsAuthority(url) ?: return false
+        return authority != ROOT_HOST && authority.endsWith(".$ROOT_HOST")
+    }
+
+    private fun httpsAuthority(url: String): String? {
+        if (url.isBlank() || url != url.trim() || url.any(Char::isISOControl)) return null
         val schemeSeparator = url.indexOf("://")
         if (schemeSeparator <= 0 || url.substring(0, schemeSeparator).lowercase() != "https") {
-            return false
+            return null
         }
         val authority = url.substring(schemeSeparator + 3)
             .substringBefore('/')
             .substringBefore('?')
             .substringBefore('#')
             .lowercase()
-        if (authority.isBlank() || '@' in authority || ':' in authority) return false
-        return authority == ROOT_HOST || authority.endsWith(".$ROOT_HOST")
+        if (authority.isBlank() || '@' in authority || ':' in authority) return null
+        return authority
     }
 
     private companion object {

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/PlayerBridgeCodec.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/PlayerBridgeCodec.kt
@@ -111,7 +111,7 @@ class PlayerBridgeCodec(
 
     private fun JsonObject.int(key: String): Int {
         val value = get(key) as? JsonPrimitive ?: return 0
-        return value.intOrNull ?: value.contentOrNull?.toIntOrNull() ?: 0
+        return value.intOrNull ?: value.contentOrNull?.toDoubleOrNull()?.toInt() ?: 0
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/PlayerBridgeCodec.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/PlayerBridgeCodec.kt
@@ -114,8 +114,10 @@ class PlayerBridgeCodec(
         return value.intOrNull ?: value.contentOrNull?.toIntOrNull() ?: 0
     }
 
-    private companion object {
-        val PLAYED_MINUTES_PATTERN = Regex("""학습시간\s*(\d+)\s*분""")
+    companion object {
+        fun create(): PlayerBridgeCodec = PlayerBridgeCodec()
+
+        private val PLAYED_MINUTES_PATTERN = Regex("""학습시간\s*(\d+)\s*분""")
     }
 }
 

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
@@ -70,14 +70,18 @@ object KlasWebAutomationScripts {
             "window.scroll(0,0);})();",
     )
 
-    /// Android WebView는 `supportMultipleWindows=false`일 때 `window.open` 호출 시 현재 웹뷰에서 바로 이동합니다.
-    /// 반면 iOS WKWebView는 네이티브(evaluateJavaScript)에서 간접 트리거된 `window.open` 팝업을 보안의 이유로 차단합니다.
-    /// 따라서 새 창 대신 현재 웹뷰(top frame)에서 페이지가 이동하도록 모든 프레임의 `window.open`을 가로챕니다.
+    /// Android WebView는 `supportMultipleWindows=false` 설정 시 새 창(window.open)이나 폼 전송을 현재 웹뷰에서 바로 처리합니다.
+    /// 반면 iOS(특히 iOS 17)의 WKWebView는 폼을 새 창으로 제출할 때(`createWebViewWith`) 폼 데이터(POST Body)가 유실되는 문제가 있습니다.
+    /// 따라서 새 창 대신 현재 웹뷰에서 페이지가 열리고, 폼도 현재 창(`_self`)으로 안전하게 제출되도록 가로챕니다.
     fun redirectWindowOpenToSameFrame(): WebScript = WebScript(
-        "(function(root){function go(url){var href=url==null||url===undefined?'':String(url);" +
+        "(function(root){function go(url,name){var href=url==null||url===undefined?'':String(url);" +
+            "if(name){try{root.top.name=name;}catch(e){}try{root.name=name;}catch(e){}}" +
             "if(href&&href!=='about:blank'){try{root.top.location.href=href;}catch(e){" +
             "try{root.location.href=href;}catch(e2){}}}return root.top||root;}" +
             "function install(w){if(!w)return;try{w.open=go;}catch(e){}" +
+            "try{if(w.HTMLFormElement&&w.HTMLFormElement.prototype){var s=w.HTMLFormElement.prototype.submit;" +
+            "w.HTMLFormElement.prototype.submit=function(){this.target='_self';return s.apply(this,arguments);};}}catch(e){}" +
+            "try{if(w.document){w.document.addEventListener('submit',function(e){if(e.target&&e.target.tagName==='FORM'){e.target.target='_self';}},true);}}catch(e){}" +
             "try{var frames=w.frames;for(var i=0;i<frames.length;i++)try{install(frames[i]);}catch(e){}}" +
             "catch(e){}}install(root);})(window);",
     )

--- a/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
+++ b/shared/src/commonMain/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScripts.kt
@@ -70,6 +70,18 @@ object KlasWebAutomationScripts {
             "window.scroll(0,0);})();",
     )
 
+    /// Android WebView는 `supportMultipleWindows=false`일 때 `window.open` 호출 시 현재 웹뷰에서 바로 이동합니다.
+    /// 반면 iOS WKWebView는 네이티브(evaluateJavaScript)에서 간접 트리거된 `window.open` 팝업을 보안의 이유로 차단합니다.
+    /// 따라서 새 창 대신 현재 웹뷰(top frame)에서 페이지가 이동하도록 모든 프레임의 `window.open`을 가로챕니다.
+    fun redirectWindowOpenToSameFrame(): WebScript = WebScript(
+        "(function(root){function go(url){var href=url==null||url===undefined?'':String(url);" +
+            "if(href&&href!=='about:blank'){try{root.top.location.href=href;}catch(e){" +
+            "try{root.location.href=href;}catch(e2){}}}return root.top||root;}" +
+            "function install(w){if(!w)return;try{w.open=go;}catch(e){}" +
+            "try{var frames=w.frames;for(var i=0;i<frames.length;i++)try{install(frames[i]);}catch(e){}}" +
+            "catch(e){}}install(root);})(window);",
+    )
+
     fun collectLectureBoardPaths(
         maxRetries: Int = 20,
         intervalMs: Int = 250,
@@ -140,6 +152,9 @@ object KlasWebAutomationScripts {
 enum class PlayerPlaybackCommand {
     PLAY,
     PAUSE,
+    MUTE,
+    UNMUTE,
+    OPEN_FULL_SCREEN,
     CLOSE_FULL_SCREEN,
 }
 
@@ -195,8 +210,20 @@ object PlayerWebScripts {
                 "bcPlayController._uniPlayerEventTarget.fire(VCPlayControllerEvent.PLAY);"
             PlayerPlaybackCommand.PAUSE ->
                 "bcPlayController._uniPlayerEventTarget.fire(VCPlayControllerEvent.PAUSE);"
+            PlayerPlaybackCommand.MUTE ->
+                "(function(){" +
+                    "try{var v=document.querySelector('video');if(v)v.muted=true;}catch(e){}" +
+                    "try{if(window.bcPlayController&&bcPlayController.getPlayController){var p=bcPlayController.getPlayController();p._isMuted=true;if(p._eventTarget)p._eventTarget.fire(VCPlayControllerEvent.MUTE);}}catch(e){}" +
+                    "})();"
+            PlayerPlaybackCommand.UNMUTE ->
+                "(function(){" +
+                    "try{var v=document.querySelector('video');if(v)v.muted=false;}catch(e){}" +
+                    "try{if(window.bcPlayController&&bcPlayController.getPlayController){var p=bcPlayController.getPlayController();p._isMuted=false;if(p._eventTarget)p._eventTarget.fire(VCPlayControllerEvent.UNMUTE);}}catch(e){}" +
+                    "})();"
+            PlayerPlaybackCommand.OPEN_FULL_SCREEN ->
+                "if(window.bcPlayController)bcPlayController.getPlayController()._eventTarget.fire(VCPlayControllerEvent.FULL_SCREEN);"
             PlayerPlaybackCommand.CLOSE_FULL_SCREEN ->
-                "bcPlayController.getPlayController()._eventTarget.fire(VCPlayControllerEvent.CLOSE_FULL_SCREEN);"
+                "if(window.bcPlayController)bcPlayController.getPlayController()._eventTarget.fire(VCPlayControllerEvent.CLOSE_FULL_SCREEN);"
         }
         return WebScript(source)
     }
@@ -206,13 +233,20 @@ object PlayerWebScripts {
             klasNativeBridgeCall("receiveInitSpeed", "speed") +
             ";clearInterval(window.__klasPlusPlayerStateInterval);" +
             "window.__klasPlusPlayerStateInterval=setInterval(function(){\$('#content-metadata').remove();" +
-            "var player=bcPlayController.getPlayController();" + klasNativeBridgeCall(
+            "var player=(window.bcPlayController&&bcPlayController.getPlayController)?bcPlayController.getPlayController():null;" +
+            "var v=document.querySelector('video');" +
+            "var isMuted=v?v.muted:(player?player._isMuted===true:false);" +
+            "var isPlaying=player&&player._isPlaying!==undefined?player._isPlaying:(v?!v.paused:false);" +
+            "var currTime=player&&player._currTime!==undefined?player._currTime:(v?v.currentTime:0);" +
+            "var duration=player&&player._duration!==undefined?player._duration:(v?v.duration:0);" +
+            "var isFullscreen=player&&player._isFullScreen!==undefined?player._isFullScreen:false;" +
+            klasNativeBridgeCall(
                 "receivePlayerStates",
-                "String(player._currTime)",
-                "String(player._duration)",
-                "String(player._isMuted)",
-                "String(player._isPlaying)",
-                "String(player._isFullScreen)",
+                "String(currTime)",
+                "String(duration)",
+                "String(isMuted)",
+                "String(isPlaying)",
+                "String(isFullscreen)",
             ) + ";},200);})();",
     )
 
@@ -241,7 +275,45 @@ object PlayerWebScripts {
         "if(window.bcPlayController){" + playback(PlayerPlaybackCommand.CLOSE_FULL_SCREEN).reveal() + "}",
     )
 
-    fun openOnlineContent(request: OnlineContentRequest): WebScript {
+    fun openFullScreenIfAvailable(): WebScript = WebScript(
+        "if(window.bcPlayController){" + playback(PlayerPlaybackCommand.OPEN_FULL_SCREEN).reveal() + "}",
+    )
+
+    fun mute(muted: Boolean): WebScript =
+        playback(if (muted) PlayerPlaybackCommand.MUTE else PlayerPlaybackCommand.UNMUTE)
+
+    fun enterPictureInPicture(): WebScript = WebScript(
+        "(function(){var video=document.querySelector('video');" +
+            "if(!video)return;" +
+            "try{if(video.webkitSetPresentationMode){video.webkitSetPresentationMode('picture-in-picture');return;}}catch(e){}" +
+            "try{if(typeof video.requestPictureInPicture==='function'){video.requestPictureInPicture();}}catch(e){}})();",
+    )
+
+    fun pictureInPicturePresentationMode(): WebScript = WebScript(
+        "(function(){var video=document.querySelector('video');" +
+            "if(!video)return 'none:paused';" +
+            "var mode=(video.webkitPresentationMode)?String(video.webkitPresentationMode):(document.pictureInPictureElement?'picture-in-picture':'inline');" +
+            "var isPaused=(video.paused===true)?'paused':'playing';" +
+            "return mode+':'+isPaused;})();",
+    )
+
+    fun isPictureInPictureSupported(): WebScript = WebScript(
+        "(function(){var video=document.querySelector('video');" +
+            "if(video&&video.webkitSetPresentationMode)return 'true';" +
+            "if(video&&video.webkitSupportsPresentationMode)return video.webkitSupportsPresentationMode('picture-in-picture')?'true':'false';" +
+            "return (document.pictureInPictureEnabled||'pictureInPictureEnabled' in document)?'true':'false';})();",
+    )
+
+    fun openOnlineContent(request: OnlineContentRequest): WebScript =
+        openOnlineContent(request, directViewer = false)
+
+    fun openOnlineContentViewer(request: OnlineContentRequest): WebScript =
+        openOnlineContent(request, directViewer = true)
+
+    private fun openOnlineContent(
+        request: OnlineContentRequest,
+        directViewer: Boolean,
+    ): WebScript {
         require(request.weekNumber >= 0 && request.weeklySequence >= 0)
         require(request.width >= 0 && request.height >= 0)
         require(request.progress in 0..100)
@@ -269,9 +341,12 @@ object PlayerWebScripts {
             request.learnTime,
         ).map(JavaScriptEncoder::encodeText)
         values += request.progress.toString()
-        if (request.progress != 100) values += JavaScriptEncoder.encodeText("C")
+        val function =
+            if (directViewer || request.progress == 100) "appModule.goViewCntnts" else "lrnCerti.checkCerti"
+        if (function == "lrnCerti.checkCerti") {
+            values += JavaScriptEncoder.encodeText("C")
+        }
         values += JavaScriptEncoder.encodeText(request.playTime)
-        val function = if (request.progress == 100) "appModule.goViewCntnts" else "lrnCerti.checkCerti"
         return WebScript("$function(${values.joinToString(",")});")
     }
 }

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/bridge/BridgeValidatorTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/bridge/BridgeValidatorTest.kt
@@ -26,6 +26,9 @@ class BridgeValidatorTest {
 
         assertTrue(policy.isTrustedUrl("https://vod.kw.ac.kr/player/content"))
         assertTrue(policy.isTrustedUrl("https://klas.kw.ac.kr/player"))
+        assertTrue(policy.isTrustedUrl("https://kw.ac.kr/"))
+        assertTrue(policy.isTrustedVideoUrl("https://vod.kw.ac.kr/player/content"))
+        assertFalse(policy.isTrustedVideoUrl("https://kw.ac.kr/"))
         assertFalse(policy.isTrustedUrl("http://vod.kw.ac.kr/player"))
         assertFalse(policy.isTrustedUrl("https://vod.kw.ac.kr.evil.example/player"))
         assertFalse(policy.isTrustedUrl("https://evil.example/?next=vod.kw.ac.kr"))

--- a/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScriptsTest.kt
+++ b/shared/src/commonTest/kotlin/com/icecream/kwklasplus/core/web/WebAutomationScriptsTest.kt
@@ -117,6 +117,49 @@ class WebAutomationScriptsTest {
     }
 
     @Test
+    fun redirectWindowOpenToSameFrameNavigatesCurrentWindow() {
+        val script = KlasWebAutomationScripts.redirectWindowOpenToSameFrame().reveal()
+        assertTrue(script.contains("w.open=go"))
+        assertTrue(script.contains("location.href=href"))
+        assertTrue(script.contains("about:blank"))
+        assertTrue(script.contains("install(frames[i])"))
+        assertTrue(!script.contains("Android."))
+    }
+
+    @Test
+    fun onlineContentViewerUsesGoViewCntntsWithoutCertFlag() {
+        val request = PlayerWebScripts.OnlineContentRequest(
+            groupCode = "G",
+            subjectId = "S",
+            year = "2026",
+            semester = "1",
+            classNumber = "01",
+            module = "M",
+            lesson = "L",
+            objectId = "O",
+            starting = "S",
+            contentsType = "V",
+            weekNumber = 2,
+            weeklySequence = 1,
+            width = 1280,
+            height = 720,
+            today = "20260717",
+            startDate = "20260701",
+            endDate = "20260731",
+            playerType = "P",
+            learnTime = "30",
+            progress = 50,
+            playTime = "10",
+        )
+        val viewer = PlayerWebScripts.openOnlineContentViewer(request).reveal()
+        assertTrue(viewer.startsWith("appModule.goViewCntnts("))
+        assertTrue(!viewer.contains(",\"C\","))
+        val certi = PlayerWebScripts.openOnlineContent(request).reveal()
+        assertTrue(certi.startsWith("lrnCerti.checkCerti("))
+        assertTrue(certi.contains(",\"C\","))
+    }
+
+    @Test
     fun nativeBridgeAdapterOwnsBridgeV1TransportDetails() {
         val source = KlasNativeBridgeScripts.installAdapter().reveal()
 

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/IosSharedDependencies.kt
@@ -17,6 +17,7 @@ import com.icecream.kwklasplus.core.legacy.LegacyPreferenceKeys
 import com.icecream.kwklasplus.core.lock.IosAppLockCredentialCodec
 import com.icecream.kwklasplus.core.lock.IosAppLockSecretStore
 import com.icecream.kwklasplus.core.lock.IosAppLockStore
+import com.icecream.kwklasplus.core.media.MediaMetadataRepository
 import com.icecream.kwklasplus.core.network.KlasSessionHttpClient
 import com.icecream.kwklasplus.core.network.KlasSessionLeaseHttpGateway
 import com.icecream.kwklasplus.core.network.KlasUserAgent
@@ -67,6 +68,10 @@ class IosSharedDependencies(
             onlineLectureEndParser = IosDeadlineDateParsers.onlineLecture,
             assignmentEndParser = IosDeadlineDateParsers.assignment,
         )
+    }
+
+    val mediaMetadataRepository: MediaMetadataRepository by lazy {
+        MediaMetadataRepository(httpClient)
     }
 
     val preferencesStore: PreferencesStore by lazy {

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/bridge/IosBridgeHosts.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/bridge/IosBridgeHosts.kt
@@ -65,3 +65,21 @@ interface SettingsBridgeHost {
     fun setBiometricEnabled(enabled: Boolean)
     fun getAppLockSettings(): String
 }
+
+interface VideoBridgeHost {
+    fun completePageLoad()
+    fun openExternalLink(url: String)
+    fun openInKLAS()
+    fun requestOnlineLecture(json: String)
+    fun receivePlayerStates(
+        currentTime: String,
+        duration: String,
+        isMuted: String,
+        isPlaying: String,
+        isFullscreen: String,
+    )
+    fun receiveInitSpeed(currentSpeed: String)
+    fun receiveVideoData(progress: String, time: String)
+    fun receiveVideoURL(videoURL: String)
+    fun performHapticFeedback(type: String)
+}

--- a/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/bridge/IosLegacyBridgeCommandHandlers.kt
+++ b/shared/src/iosMain/kotlin/com/icecream/kwklasplus/core/bridge/IosLegacyBridgeCommandHandlers.kt
@@ -156,6 +156,35 @@ class IosSettingsLegacyBridgeCommandHandler(
     }
 }
 
+class IosVideoLegacyBridgeCommandHandler(
+    private val host: VideoBridgeHost,
+) : BridgeCommandHandler {
+    override suspend fun handle(command: ValidatedBridgeCommand) = command.execute {
+        when (command.methodId) {
+            BridgeMethodId.VIDEO_COMPLETE_PAGE_LOAD -> host.completePageLoad()
+            BridgeMethodId.VIDEO_OPEN_EXTERNAL_LINK -> host.openExternalLink(command.text(0))
+            BridgeMethodId.VIDEO_OPEN_IN_KLAS -> host.openInKLAS()
+            BridgeMethodId.VIDEO_REQUEST_ONLINE_LECTURE -> host.requestOnlineLecture(command.text(0))
+            BridgeMethodId.VIDEO_RECEIVE_PLAYER_STATES -> host.receivePlayerStates(
+                command.text(0),
+                command.text(1),
+                command.text(2),
+                command.text(3),
+                command.text(4),
+            )
+            BridgeMethodId.VIDEO_RECEIVE_INIT_SPEED -> host.receiveInitSpeed(command.text(0))
+            BridgeMethodId.VIDEO_RECEIVE_VIDEO_DATA -> host.receiveVideoData(
+                command.text(0),
+                command.text(1),
+            )
+            BridgeMethodId.VIDEO_RECEIVE_VIDEO_URL -> host.receiveVideoURL(command.text(0))
+            BridgeMethodId.VIDEO_PERFORM_HAPTIC_FEEDBACK -> host.performHapticFeedback(command.text(0))
+            else -> return@execute false
+        }
+        true
+    }
+}
+
 class IosSettingsLegacySynchronousBridgeCommandHandler(
     private val host: SettingsBridgeHost,
 ) : SynchronousBridgeCommandHandler {

--- a/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/bridge/IosLegacyBridgeCommandHandlerTest.kt
+++ b/shared/src/iosTest/kotlin/com/icecream/kwklasplus/core/bridge/IosLegacyBridgeCommandHandlerTest.kt
@@ -61,6 +61,50 @@ class IosLegacyBridgeCommandHandlerTest {
         assertEquals(1, host.completeCount)
     }
 
+    @Test
+    fun videoCommandsReachHost() = runSuspendTest {
+        val host = RecordingVideoHost()
+        val handler = IosVideoLegacyBridgeCommandHandler(host)
+        handler.handle(command(BridgeMethodId.VIDEO_COMPLETE_PAGE_LOAD))
+        handler.handle(command(BridgeMethodId.VIDEO_OPEN_IN_KLAS))
+        handler.handle(command(BridgeMethodId.VIDEO_REQUEST_ONLINE_LECTURE, BridgeValue.Text("{}")))
+        handler.handle(
+            command(
+                BridgeMethodId.VIDEO_RECEIVE_PLAYER_STATES,
+                BridgeValue.Text("1"),
+                BridgeValue.Text("10"),
+                BridgeValue.Text("true"),
+                BridgeValue.Text("false"),
+                BridgeValue.Text("false"),
+            ),
+        )
+        handler.handle(command(BridgeMethodId.VIDEO_RECEIVE_INIT_SPEED, BridgeValue.Text("1.5")))
+        handler.handle(
+            command(
+                BridgeMethodId.VIDEO_RECEIVE_VIDEO_DATA,
+                BridgeValue.Text("progress"),
+                BridgeValue.Text("time"),
+            ),
+        )
+        handler.handle(
+            command(
+                BridgeMethodId.VIDEO_RECEIVE_VIDEO_URL,
+                BridgeValue.Text("https://vod.kw.ac.kr/player"),
+            ),
+        )
+        handler.handle(command(BridgeMethodId.VIDEO_OPEN_EXTERNAL_LINK, BridgeValue.Text("https://example.com")))
+        handler.handle(command(BridgeMethodId.VIDEO_PERFORM_HAPTIC_FEEDBACK, BridgeValue.Text("CLOCK_TICK")))
+        assertEquals(1, host.completeCount)
+        assertEquals(1, host.openInKlasCount)
+        assertEquals(listOf("{}"), host.onlineLectures)
+        assertEquals(listOf("1" to "10"), host.playerStates)
+        assertEquals(listOf("1.5"), host.speeds)
+        assertEquals(listOf("progress" to "time"), host.videoData)
+        assertEquals(listOf("https://vod.kw.ac.kr/player"), host.videoUrls)
+        assertEquals(listOf("https://example.com"), host.externalLinks)
+        assertEquals(listOf("CLOCK_TICK"), host.haptics)
+    }
+
     private fun command(
         methodId: BridgeMethodId,
         vararg arguments: BridgeValue,
@@ -165,4 +209,58 @@ private class RecordingSettingsHost : SettingsBridgeHost {
     override fun setAppLockPassword() = Unit
     override fun setBiometricEnabled(enabled: Boolean) = Unit
     override fun getAppLockSettings(): String = AppLockSettings(false, false, false).toLegacyJson()
+}
+
+private class RecordingVideoHost : VideoBridgeHost {
+    var completeCount = 0
+    var openInKlasCount = 0
+    val onlineLectures = mutableListOf<String>()
+    val playerStates = mutableListOf<Pair<String, String>>()
+    val speeds = mutableListOf<String>()
+    val videoData = mutableListOf<Pair<String, String>>()
+    val videoUrls = mutableListOf<String>()
+    val externalLinks = mutableListOf<String>()
+    val haptics = mutableListOf<String>()
+
+    override fun completePageLoad() {
+        completeCount += 1
+    }
+
+    override fun openExternalLink(url: String) {
+        externalLinks += url
+    }
+
+    override fun openInKLAS() {
+        openInKlasCount += 1
+    }
+
+    override fun requestOnlineLecture(json: String) {
+        onlineLectures += json
+    }
+
+    override fun receivePlayerStates(
+        currentTime: String,
+        duration: String,
+        isMuted: String,
+        isPlaying: String,
+        isFullscreen: String,
+    ) {
+        playerStates += currentTime to duration
+    }
+
+    override fun receiveInitSpeed(currentSpeed: String) {
+        speeds += currentSpeed
+    }
+
+    override fun receiveVideoData(progress: String, time: String) {
+        videoData += progress to time
+    }
+
+    override fun receiveVideoURL(videoURL: String) {
+        videoUrls += videoURL
+    }
+
+    override fun performHapticFeedback(type: String) {
+        haptics += type
+    }
 }


### PR DESCRIPTION
## Summary

* iOS에 Android와 동일한 온라인 강의 재생 및 Picture-in-Picture(PIP) 수명주기를 구현
* VideoView와 VideoPlayerOverlay가 16:9 규격으로 반응형(가로/세로) 비디오 뷰와 네이티브 컨트롤러(재생/일시정지, ±10초 이동, 배속, 음소거, 전체화면)를 제공하며, 백그라운드 klasHolder 웹뷰로 출석 진도율을 실시간 동기화
* PlayerWebScripts, PlayerBridgeCodec, BridgeValidator를 KMP 공통 모듈에 두고 Android와 동일한 비디오 제어 및 레거시 브리지 프로토콜(receivePlayerStates, requestOnlineLecture, openInKlas 등)을 처리
* 인앱 [PIP로 재생] 버튼 또는 네이티브 전체화면의 PIP 아이콘 클릭 시, 검은 화면 깜빡임 없이 즉시 PIP를 띄우며 강의 목록(LectureView)으로 자동 복귀
* 사용자가 강의 목록이나 홈 화면으로 나가도 HomeCoordinator의 activeVideoModel을 통해 비디오 세션을 메모리에 유지하여 영상과 출석 체크가 끊김 없이 지속
* PIP 창의 '복귀(화면 키우기)' 버튼 클릭 시 기존 세션을 그대로 이어받아 VideoView로 자동 복구 네비게이션하며, X 버튼 클릭 시에는 화면 이동 없이 백그라운드 세션만 메모리에서 해제
* AVAudioSessionCategoryPlayback 활성화 및 Info.plist 백그라운드 오디오 모드를 등록하여 무중단 재생을 보장

## Test Plan

* `./gradlew :shared:iosSimulatorArm64Test --tests 'com.icecream.kwklasplus.core.web.PlayerBridgeCodecTest' --tests 'com.icecream.kwklasplus.core.web.WebAutomationScriptsTest' --tests 'com.icecream.kwklasplus.core.bridge.BridgeValidatorTest'`
* `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' test -only-testing:iosAppTests/IosVideoHostTests`
* 온라인 강의 선택 → 본인인증 완료 시 플레이어(VideoPlayerOverlay) 자동 진입 및 16:9 비율 확인
* 재생/일시정지, ±10초 이동, 배속 변경, 음소거, 전체화면 컨트롤 정상 동작 및 출석 진도율 실시간 동기화 확인
* [PIP로 재생] 버튼 탭 → 깜빡임 없이 PiP 생성 및 LectureView로 자동 복귀
* Native 전체화면에서 PiP 아이콘 탭 → 영상 멈춤 없이 PiP 유지 및 LectureView 복귀
* PiP 재생 중 홈 화면 진입 / 화면 잠금 → 오디오 및 영상 끊김 없이 무중단 재생 유지
* PiP 창에서 복귀 버튼 탭 → 재생 중 및 일시정지(Pause) 상태 모두 VideoView 플레이어로 정상 복귀
* PiP 창에서 X(닫기) 버튼 탭 → 화면 이동 없이 LectureView 유지 및 백그라운드 세션 해제
* PiP 창에서 일시정지 후 복귀 버튼 탭 → 메인 화면으로 정상 복귀
* PiP 활성 상태에서 다른 강의 추가 재생 시 알림창 표시 → 사용자 승인 시 기존 강의 종료 후 새로운 강의 재생 시작

## iOS

https://github.com/user-attachments/assets/b0c3d979-05ce-4026-8643-339570587f7b

## iPad

https://github.com/user-attachments/assets/1168594f-704a-40df-b275-6afc67aa522d