### PR TITLE
feat: Android 도서관 QR 위젯 개선

### DIFF
--- a/androidApp/src/androidTest/java/com/icecream/kwklasplus/LibraryQrModalRecreationTest.kt
+++ b/androidApp/src/androidTest/java/com/icecream/kwklasplus/LibraryQrModalRecreationTest.kt
@@ -1,8 +1,14 @@
 package com.icecream.kwklasplus
 
+import android.content.ComponentName
+import android.content.pm.ActivityInfo
+import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.icecream.kwklasplus.modal.LibraryQRModal
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -14,5 +20,16 @@ class LibraryQrModalRecreationTest {
 
         assertNotNull(recreated)
         assertNotNull(LibraryQRModal.newInstance(isWidget = true).arguments)
+    }
+    @Test
+    fun widgetHostUsesSeparateTaskOutsideRecents() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val manager = context.packageManager
+        val widget = manager.getActivityInfo(ComponentName(context, LibraryQRWidgetActivity::class.java), 0)
+        val home = manager.getActivityInfo(ComponentName(context, HomeActivity::class.java), 0)
+
+        assertNotEquals(home.taskAffinity, widget.taskAffinity)
+        assertEquals(ActivityInfo.LAUNCH_SINGLE_TASK, widget.launchMode)
+        assertTrue(widget.flags and ActivityInfo.FLAG_EXCLUDE_FROM_RECENTS != 0)
     }
 }

--- a/androidApp/src/androidTest/java/com/icecream/kwklasplus/feature/library/LibraryQrContentTest.kt
+++ b/androidApp/src/androidTest/java/com/icecream/kwklasplus/feature/library/LibraryQrContentTest.kt
@@ -1,5 +1,7 @@
 package com.icecream.kwklasplus.feature.library
 
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.v2.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -14,7 +16,7 @@ class LibraryQrContentTest {
     val composeRule = createComposeRule()
 
     @Test
-    fun loadingStateAndRefreshActionAreExposed() {
+    fun loadingStateDisablesRefresh() {
         var refreshed = false
         composeRule.setContent {
             KlasPlusTheme {
@@ -22,13 +24,33 @@ class LibraryQrContentTest {
                     state = LibraryQrUiState(loading = true),
                     onRefreshClick = { refreshed = true },
                     onSettingsClick = {},
-                    onAddWidgetClick = {},
                 )
             }
         }
 
         composeRule.onNodeWithTag("library_qr_loading").assertIsDisplayed()
+        composeRule.onNodeWithTag("library_qr_refresh").assertIsNotEnabled()
+        assertTrue(!refreshed)
+    }
+
+    @Test
+    fun widgetErrorExposesSettingsAndRetry() {
+        var settingsOpened = false
+        var refreshed = false
+        composeRule.setContent {
+            KlasPlusTheme {
+                LibraryQrContent(
+                    state = LibraryQrUiState(loading = false),
+                    onRefreshClick = { refreshed = true },
+                    onSettingsClick = { settingsOpened = true },
+                )
+            }
+        }
+        composeRule.onNodeWithText("도서관 출입증 정보를 가져올 수 없습니다. 설정에서 입력한 정보가 올바른지 확인한 후 다시 시도해주세요.")
+            .assertIsDisplayed()
+        composeRule.onNodeWithTag("library_qr_settings").performClick()
         composeRule.onNodeWithTag("library_qr_refresh").performClick()
+        assertTrue(settingsOpened)
         assertTrue(refreshed)
     }
 }

--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -56,6 +56,10 @@
             android:supportsPictureInPicture="true" />
         <activity
             android:name=".LibraryQRWidgetActivity"
+            android:taskAffinity="${applicationId}.libraryqr"
+            android:launchMode="singleTask"
+            android:excludeFromRecents="true"
+            android:autoRemoveFromRecents="true"
             android:exported="false"
             android:theme="@style/Theme.AppCompat.Transparent.NoActionBar" />
 

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/HomeActivity.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/HomeActivity.kt
@@ -113,6 +113,38 @@ import kotlin.system.exitProcess
 private const val VIEWPORT_LAYOUT_RETRY_LIMIT = 12
 
 class HomeActivity : AppCompatActivity() {
+    companion object {
+        const val ACTION_OPEN_LIBRARY_SETTINGS = "com.icecream.kwklasplus.OPEN_LIBRARY_SETTINGS"
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        if (intent.action == ACTION_OPEN_LIBRARY_SETTINGS &&
+            com.icecream.kwklasplus.manager.AppLockManager.isAppLockEnabled(this) &&
+            !com.icecream.kwklasplus.manager.AppLockManager.isUnlocked
+        ) {
+            startActivity(Intent(this, LockActivity::class.java).apply {
+                putExtra("MODE", "UNLOCK")
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            })
+        }
+    }
+
+    override fun onResumeFragments() {
+        super.onResumeFragments()
+        if (isFinishing || intent.action != ACTION_OPEN_LIBRARY_SETTINGS) return
+        if (com.icecream.kwklasplus.manager.AppLockManager.isAppLockEnabled(this) &&
+            !com.icecream.kwklasplus.manager.AppLockManager.isUnlocked
+        ) return
+        if (supportFragmentManager.findFragmentByTag(LibraryQRSettingsBottomSheetDialog.TAG) == null) {
+            LibraryQRSettingsBottomSheetDialog().show(
+                supportFragmentManager, LibraryQRSettingsBottomSheetDialog.TAG,
+            )
+        }
+        intent.action = null
+    }
+
     private val qrScanLaunchGuard = QrScanLaunchGuard()
     private val qrScanLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
@@ -190,7 +222,11 @@ class HomeActivity : AppCompatActivity() {
         if (sessionId == null) {
             showLoginErrorToast()
             finish()
-            startActivity(Intent(this@HomeActivity, MainActivity::class.java))
+            startActivity(Intent(this@HomeActivity, MainActivity::class.java).apply {
+                if (this@HomeActivity.intent.action == ACTION_OPEN_LIBRARY_SETTINGS) {
+                    action = ACTION_OPEN_LIBRARY_SETTINGS
+                }
+            })
             return
         }
 

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/LibraryQRWidget.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/LibraryQRWidget.kt
@@ -35,8 +35,10 @@ internal fun updateAppWidget(
     appWidgetId: Int
 ) {
     val views = RemoteViews(context.packageName, R.layout.library_q_r_widget)
-    val intent = Intent(context, LibraryQRWidgetActivity::class.java)
-    val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+    val intent = Intent(context, LibraryQRWidgetActivity::class.java).apply {
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT)
     views.setOnClickPendingIntent(R.id.widget_qr_code_img, pendingIntent)
 
     appWidgetManager.updateAppWidget(appWidgetId, views)

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/LibraryQRWidgetActivity.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/LibraryQRWidgetActivity.kt
@@ -1,12 +1,10 @@
 package com.icecream.kwklasplus
 
-import android.content.Context
+import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.widget.Toast
 import androidx.fragment.app.DialogFragment
 import com.icecream.kwklasplus.modal.LibraryQRModal
-import com.icecream.kwklasplus.getLibraryPassword
 
 class LibraryQRWidgetActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -17,8 +15,11 @@ class LibraryQRWidgetActivity : AppCompatActivity() {
         val phone = sharedPreferences.getString(AppPrefs.LIBRARY_PHONE, null)
         val password = getLibraryPassword()
 
-        if(stdNumber == null || phone == null || password == null) {
-            Toast.makeText(this, "먼저 앱에서 모바일 학생증 설정을 완료해주세요.", Toast.LENGTH_SHORT).show()
+        if (stdNumber.isNullOrBlank() || phone.isNullOrBlank() || password.isNullOrBlank()) {
+            startActivity(Intent(this, HomeActivity::class.java).apply {
+                action = HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            })
             finish()
             return
         }

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/LibraryQRWidgetActivity.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/LibraryQRWidgetActivity.kt
@@ -23,6 +23,7 @@ class LibraryQRWidgetActivity : AppCompatActivity() {
             return
         }
 
+        if (savedInstanceState != null) return
         val modal = LibraryQRModal.newInstance(true)
         modal.setStyle(DialogFragment.STYLE_NORMAL, R.style.RoundCornerBottomSheetDialogTheme)
         modal.show(supportFragmentManager, LibraryQRModal.TAG)

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/LoginActivity.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/LoginActivity.kt
@@ -141,7 +141,11 @@ class LoginActivity : AppCompatActivity() {
     private fun openMainActivity() {
         password = ""
         finish()
-        startActivity(Intent(this, MainActivity::class.java))
+        startActivity(Intent(this, MainActivity::class.java).apply {
+                        if (this@LoginActivity.intent.action == HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS) {
+                            action = HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS
+                        }
+                    })
     }
 
     override fun onDestroy() {

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/MainActivity.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/MainActivity.kt
@@ -79,14 +79,22 @@ class MainActivity : AppCompatActivity() {
         val credential = runCatching { appDependencies.credentialStore.load() }.getOrNull()
         if (credential == null) {
             finish()
-            startActivity(Intent(this, LoginActivity::class.java))
+            startActivity(Intent(this, LoginActivity::class.java).apply {
+                        if (this@MainActivity.intent.action == HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS) {
+                            action = HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS
+                        }
+                    })
             return
         }
         when (val leaseResult = appDependencies.sessionLeaseManager.maintain()) {
             is SessionLeaseResult.Active -> {
                 appDependencies.sessionKeepAlive.onSessionAvailable(leaseResult.nextCheckAfterMillis)
                 isHomeStarted = true
-                startActivity(Intent(this, HomeActivity::class.java))
+                startActivity(Intent(this, HomeActivity::class.java).apply {
+                        if (this@MainActivity.intent.action == HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS) {
+                            action = HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS
+                        }
+                    })
                 finish()
                 return
             }
@@ -114,7 +122,11 @@ class MainActivity : AppCompatActivity() {
                     isLoginActivityStarted = true
                     isHomeStarted = true
                     appDependencies.sessionKeepAlive.onSessionAvailable()
-                    startActivityWithLock(Intent(this@MainActivity, HomeActivity::class.java))
+                    startActivityWithLock(Intent(this@MainActivity, HomeActivity::class.java).apply {
+                        if (this@MainActivity.intent.action == HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS) {
+                            action = HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS
+                        }
+                    })
                     finish()
                 }
                 is LoginResult.UserActionRequired -> showSecurityActionRequiredDialog()
@@ -186,7 +198,11 @@ class MainActivity : AppCompatActivity() {
             .setMessage(message ?: "학번 또는 비밀번호를 확인한 후 다시 로그인해주세요.")
             .setPositiveButton("확인") { _, _ ->
                 finish()
-                startActivity(Intent(this@MainActivity, LoginActivity::class.java))
+                startActivity(Intent(this@MainActivity, LoginActivity::class.java).apply {
+                        if (this@MainActivity.intent.action == HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS) {
+                            action = HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS
+                        }
+                    })
             }
             .setCancelable(false)
             .create()

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/feature/library/LibraryQrContent.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/feature/library/LibraryQrContent.kt
@@ -3,8 +3,8 @@ package com.icecream.kwklasplus.feature.library
 import android.graphics.Bitmap
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,16 +13,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ErrorOutline
 import androidx.compose.material.icons.outlined.Refresh
-import androidx.compose.material3.Button
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.FilledTonalIconButton
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,9 +34,6 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.icecream.kwklasplus.ui.theme.KlasButtonHeight
-import com.icecream.kwklasplus.ui.theme.KlasControlShape
-import com.icecream.kwklasplus.ui.theme.klasInverseButtonColors
 
 data class LibraryQrUiState(
     val name: String = "",
@@ -42,8 +41,6 @@ data class LibraryQrUiState(
     val bitmap: Bitmap? = null,
     val loading: Boolean = true,
     val secondsRemaining: Int = 30,
-    val isWidgetEntry: Boolean = false,
-    val canAddWidget: Boolean = false,
 )
 
 @Composable
@@ -51,7 +48,6 @@ fun LibraryQrContent(
     state: LibraryQrUiState,
     onRefreshClick: () -> Unit,
     onSettingsClick: () -> Unit,
-    onAddWidgetClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -68,52 +64,84 @@ fun LibraryQrContent(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            IconButton(
+            FilledTonalButton(
                 onClick = onRefreshClick,
+                enabled = !state.loading,
+                contentPadding = PaddingValues(horizontal = 12.dp),
                 modifier = Modifier.testTag("library_qr_refresh"),
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.Refresh,
-                    contentDescription = "QR 코드 새로고침, ${state.secondsRemaining}초 남음",
-                    tint = MaterialTheme.colorScheme.primary,
+                Icon(Icons.Outlined.Refresh, contentDescription = null)
+                Text(
+                    text = when {
+                        state.loading -> "불러오는 중"
+                        state.bitmap != null -> "${state.secondsRemaining}초 후 갱신"
+                        else -> "새로고침"
+                    },
+                    modifier = Modifier.padding(start = 8.dp),
                 )
             }
-            if (!state.isWidgetEntry) {
-                OutlinedButton(onClick = onSettingsClick) {
-                    Text("설정")
-                }
+            FilledTonalIconButton(
+                onClick = onSettingsClick,
+                modifier = Modifier.testTag("library_qr_settings"),
+            ) {
+                Icon(Icons.Outlined.Settings, contentDescription = "출입증 설정")
             }
         }
         Spacer(Modifier.height(20.dp))
-        Text(
-            text = state.name,
-            style = MaterialTheme.typography.headlineSmall,
-            fontWeight = FontWeight.Bold,
-            color = MaterialTheme.colorScheme.onSurface,
-            textAlign = TextAlign.Center,
-        )
-        Text(
-            text = state.details,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-        )
-        Spacer(Modifier.height(20.dp))
-        when {
-            state.loading -> CircularProgressIndicator(
-                modifier = Modifier.testTag("library_qr_loading"),
-            )
-            state.bitmap != null -> Image(
-                bitmap = state.bitmap.asImageBitmap(),
-                contentDescription = "중앙도서관 출입증 QR",
-                modifier = Modifier
-                    .size(220.dp)
-                    .testTag("library_qr_image"),
-            )
-            else -> Text(
-                text = "QR 코드를 표시할 수 없습니다.",
-                color = MaterialTheme.colorScheme.error,
-            )
+        Surface(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(28.dp),
+            color = MaterialTheme.colorScheme.surfaceContainerLow,
+        ) {
+            Column(
+                modifier = Modifier.fillMaxWidth().padding(24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                if (!state.loading && state.bitmap != null) {
+                    Text(
+                        text = state.name,
+                        style = MaterialTheme.typography.headlineSmall,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = TextAlign.Center,
+                    )
+                    Text(
+                        text = state.details,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                    )
+                    Spacer(Modifier.height(20.dp))
+                }
+                when {
+                    state.loading -> {
+                        Spacer(Modifier.height(12.dp))
+                        CircularProgressIndicator(
+                        modifier = Modifier.testTag("library_qr_loading"),
+                    )
+                        Text("불러오는 중", style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface)
+                    }
+                    state.bitmap != null -> Image(
+                        bitmap = state.bitmap.asImageBitmap(),
+                        contentDescription = "중앙도서관 출입증 QR",
+                        modifier = Modifier
+                            .size(220.dp)
+                            .testTag("library_qr_image"),
+                    )
+                    else -> {
+                        Surface(shape = RoundedCornerShape(20.dp),
+                            color = MaterialTheme.colorScheme.errorContainer) {
+                            Icon(Icons.Outlined.ErrorOutline, null, Modifier.padding(16.dp).size(32.dp),
+                                tint = MaterialTheme.colorScheme.onErrorContainer)
+                        }
+                        Text("도서관 출입증 정보를 가져올 수 없습니다. 설정에서 입력한 정보가 올바른지 확인한 후 다시 시도해주세요.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant, textAlign = TextAlign.Center)
+                    }
+                }
+            }
         }
         Spacer(Modifier.height(20.dp))
         Text(
@@ -122,22 +150,5 @@ fun LibraryQrContent(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
-        if (!state.isWidgetEntry && state.canAddWidget) {
-            Spacer(Modifier.height(20.dp))
-            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
-                Box(modifier = Modifier.padding(12.dp)) {
-                    Button(
-                        onClick = onAddWidgetClick,
-                        shape = KlasControlShape,
-                        colors = klasInverseButtonColors(),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(KlasButtonHeight),
-                    ) {
-                        Text("홈 화면에 학생증 위젯 추가하기")
-                    }
-                }
-            }
-        }
     }
 }

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/manager/AppLifecycleObserver.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/manager/AppLifecycleObserver.kt
@@ -18,7 +18,6 @@ class AppLifecycleObserver(
     private val sessionKeepAlive: AndroidSessionKeepAlive,
 ) : DefaultLifecycleObserver, Application.ActivityLifecycleCallbacks {
 
-    private var currentActivity: Activity? = null
     private val policy = AppLockPolicy()
 
     init {
@@ -28,15 +27,16 @@ class AppLifecycleObserver(
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
         sessionKeepAlive.onForeground()
-        
+    }
+
+    private fun requestUnlockIfNeeded(activity: Activity) {
         val state = AppLockState(AppLockManager.isAppLockEnabled(context), AppLockManager.isUnlocked)
-        val isExemptHost = currentActivity is LockActivity || currentActivity is LibraryQRWidgetActivity
+        val isExemptHost = activity is LockActivity || activity is LibraryQRWidgetActivity
         if (policy.shouldRequestUnlock(state, isExemptHost)) {
-            val intent = Intent(context, LockActivity::class.java).apply {
-                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
+            activity.startActivity(Intent(activity, LockActivity::class.java).apply {
+                addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT)
                 putExtra("MODE", "UNLOCK")
-            }
-            context.startActivity(intent)
+            })
         }
     }
 
@@ -48,10 +48,12 @@ class AppLifecycleObserver(
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
-    override fun onActivityStarted(activity: Activity) { currentActivity = activity }
-    override fun onActivityResumed(activity: Activity) { currentActivity = activity }
+    override fun onActivityStarted(activity: Activity) {}
+    override fun onActivityResumed(activity: Activity) {
+        requestUnlockIfNeeded(activity)
+    }
     override fun onActivityPaused(activity: Activity) {}
-    override fun onActivityStopped(activity: Activity) { if (currentActivity == activity) currentActivity = null }
+    override fun onActivityStopped(activity: Activity) {}
     override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
     override fun onActivityDestroyed(activity: Activity) {}
 }

--- a/androidApp/src/main/kotlin/com/icecream/kwklasplus/modal/LibraryQRModal.kt
+++ b/androidApp/src/main/kotlin/com/icecream/kwklasplus/modal/LibraryQRModal.kt
@@ -1,13 +1,9 @@
 package com.icecream.kwklasplus.modal
 
-import android.app.PendingIntent
-import android.appwidget.AppWidgetManager
-import android.content.ComponentName
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.Configuration
 import android.graphics.Color
-import android.os.Build
 import android.os.Bundle
 import android.os.CountDownTimer
 import android.view.View
@@ -26,7 +22,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.icecream.kwklasplus.AppPrefs
-import com.icecream.kwklasplus.LibraryQRWidget
+import com.icecream.kwklasplus.HomeActivity
 import com.icecream.kwklasplus.appDependencies
 import com.icecream.kwklasplus.appPreferences
 import com.icecream.kwklasplus.core.library.AndroidLibraryService
@@ -51,10 +47,7 @@ class LibraryQRModal : KlasBottomSheetDialogFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         libraryService = requireContext().appDependencies.libraryService
-        uiState = LibraryQrUiState(
-            isWidgetEntry = isWidget,
-            canAddWidget = !isWidget && !isWidgetAdded(),
-        )
+        uiState = LibraryQrUiState()
     }
 
     override fun onCreateView(
@@ -72,7 +65,6 @@ class LibraryQRModal : KlasBottomSheetDialogFragment() {
                         state = uiState,
                         onRefreshClick = { lifecycleScope.launch { refreshQrCode() } },
                         onSettingsClick = ::showSettingsDialog,
-                        onAddWidgetClick = ::requestPinWidget,
                     )
                 }
             }
@@ -104,27 +96,15 @@ class LibraryQRModal : KlasBottomSheetDialogFragment() {
         }
     }
 
-    private fun isWidgetAdded(): Boolean {
-        val manager = AppWidgetManager.getInstance(context)
-        val component = context?.let { ComponentName(it, LibraryQRWidget::class.java) }
-        return manager.getAppWidgetIds(component).isNotEmpty()
-    }
-
-    private fun requestPinWidget() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-        val manager = AppWidgetManager.getInstance(context)
-        if (!manager.isRequestPinAppWidgetSupported) return
-        val provider = context?.let { ComponentName(it, LibraryQRWidget::class.java) } ?: return
-        val callback = PendingIntent.getBroadcast(
-            context,
-            0,
-            Intent(context, LibraryQRWidget::class.java),
-            PendingIntent.FLAG_IMMUTABLE,
-        )
-        manager.requestPinAppWidget(provider, null, callback)
-    }
-
     private fun showSettingsDialog() {
+        if (isWidget) {
+            startActivity(Intent(requireContext(), HomeActivity::class.java).apply {
+                action = HomeActivity.ACTION_OPEN_LIBRARY_SETTINGS
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            })
+            dismiss()
+            return
+        }
         LibraryQRSettingsBottomSheetDialog().apply {
             setOnSaveCompleteListener {
                 lifecycleScope.launch { refreshQrCode() }
@@ -134,6 +114,7 @@ class LibraryQRModal : KlasBottomSheetDialogFragment() {
 
     private fun startCountDownTimer() {
         countDownTimer?.cancel()
+        if (uiState.bitmap == null || uiState.loading) return
         countDownTimer = object : CountDownTimer(REFRESH_INTERVAL, 1000) {
             override fun onTick(millisUntilFinished: Long) {
                 uiState = uiState.copy(secondsRemaining = (millisUntilFinished / 1000).toInt())
@@ -146,6 +127,8 @@ class LibraryQRModal : KlasBottomSheetDialogFragment() {
     }
 
     private suspend fun refreshQrCode() {
+        if (uiState.loading) return
+        countDownTimer?.cancel()
         val account = loadAccount()
         if (account == null) {
             Toast.makeText(
@@ -163,7 +146,7 @@ class LibraryQRModal : KlasBottomSheetDialogFragment() {
 
     private suspend fun refreshQrCodeWithoutCache(account: LibraryAccount) {
         libraryService.clearCache(account.studentNumber, account.phone, account.password)
-        refreshQrCode()
+        displayQr(account)
     }
 
     private suspend fun displayQr(account: LibraryAccount) {
@@ -225,11 +208,12 @@ class LibraryQRModal : KlasBottomSheetDialogFragment() {
             return
         }
         uiState = uiState.copy(loading = false, bitmap = null)
+        countDownTimer?.cancel()
+        if (isWidget) return
         MaterialAlertDialogBuilder(requireContext())
             .setTitle("오류")
             .setMessage(
-                "모바일 학생증 정보를 가져올 수 없습니다.\n" +
-                    "모바일 학생증 설정에서 입력한 정보가 올바른지 확인한 후 다시 시도해주세요.",
+                "도서관 출입증 정보를 가져올 수 없습니다. 설정에서 입력한 정보가 올바른지 확인한 후 다시 시도해주세요.",
             )
             .setPositiveButton("확인", null)
             .show()

--- a/androidApp/src/main/res/values-v21/styles.xml
+++ b/androidApp/src/main/res/values-v21/styles.xml
@@ -12,15 +12,6 @@
         <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>
 
-    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowIsFloating">true</item>
-        <item name="android:backgroundDimEnabled">true</item>
-    </style>
-
     <style name="popupOverflowMenu" parent="@style/Widget.MaterialComponents.PopupMenu.Overflow">
         <item name="android:popupBackground">@drawable/rounded_menu_background</item>
     </style>

--- a/androidApp/src/main/res/values-v31/styles.xml
+++ b/androidApp/src/main/res/values-v31/styles.xml
@@ -14,15 +14,6 @@
         <item name="android:clipToOutline">true</item>
     </style>
 
-    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
-        <item name="android:windowIsTranslucent">true</item>
-        <item name="android:windowBackground">@android:color/transparent</item>
-        <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowIsFloating">true</item>
-        <item name="android:backgroundDimEnabled">true</item>
-    </style>
-
     <style name="popupOverflowMenu" parent="@style/Widget.MaterialComponents.PopupMenu.Overflow">
         <item name="android:popupBackground">@drawable/rounded_menu_background</item>
     </style>

--- a/androidApp/src/main/res/values/styles.xml
+++ b/androidApp/src/main/res/values/styles.xml
@@ -10,13 +10,13 @@
         <item name="android:textColor">?android:attr/textColorPrimary</item>
     </style>
 
-    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Theme.AppCompat.Transparent.NoActionBar" parent="Theme.KWQRCheckin">
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowNoTitle">true</item>
-        <item name="android:windowIsFloating">true</item>
-        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:windowIsFloating">false</item>
+        <item name="android:backgroundDimEnabled">false</item>
     </style>
 
     <style name="popupOverflowMenu" parent="@style/Widget.MaterialComponents.PopupMenu.Overflow">


### PR DESCRIPTION
## 변경 사항
- QR 위젯 Activity를 앱과 별도 task로 분리해, 기존 앱이 실행 중이어도 앱 잠금을 우회해 QR을 표시합니다.
- QR 시트에 설정 버튼을 추가하여 위젯 화면에서 바로 출입증 설정 화면으로 이동할 수 있도록 했습니다. 설정 진입 시 앱 잠금 정책이 적용됩니다.
- QR 시트 상단 새로고침 버튼에 남은 갱신 시간을 표시했습니다.
- QR 조회 실패 시 오류 아이콘과 설정 확인 안내를 표시하며, 실패 상태에서 타이머가 재시작되지 않도록 수정했습니다.
- QR 조회 실패 시 Activity가 crash 되는 이슈 #32 를 수정했습니다.
- 출입증 정보가 비어 있는 상태에서 위젯을 누르면 출입증 설정 시트로 이동합니다. 설정 진입 시 앱 잠금 정책을 적용하며, 로그인이 필요하면 로그인 완료 후 설정 화면을 엽니다.