### PR TITLE
feat(ios): 화면 스와이프 뒤로가기(Interactive Pop Gesture) 지원

### DIFF
--- a/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -630,6 +630,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/App/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "KLAS+";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = NO;
@@ -659,6 +660,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/App/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "KLAS+";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = NO;

--- a/iosApp/iosApp/App/Info.plist
+++ b/iosApp/iosApp/App/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>KLAS+</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/iosApp/iosApp/Features/Home/HomeCoordinator.swift
+++ b/iosApp/iosApp/Features/Home/HomeCoordinator.swift
@@ -38,7 +38,13 @@ enum QrAttendancePhase: Equatable {
 
 @MainActor
 final class HomeCoordinator: ObservableObject {
-    @Published var path = NavigationPath()
+    @Published var path = NavigationPath() {
+        didSet {
+            if !path.isEmpty {
+                endIdCardModalIfNeeded()
+            }
+        }
+    }
     @Published private(set) var bootstrapPhase: HomeBootstrapPhase = .loading
     @Published private(set) var homeHolder: WebViewHolder?
     @Published var isPageLoading = true
@@ -441,6 +447,7 @@ final class HomeCoordinator: ObservableObject {
         isIdCardModalActive = true
         captureIdCardBrightness()
         UIScreen.main.brightness = 1.0
+        homeHolder?.webView.allowsBackForwardNavigationGestures = false
 
         let state = IdCardQrRequestState()
         let notifyWeb: () -> Void = { [weak self] in
@@ -478,6 +485,9 @@ final class HomeCoordinator: ObservableObject {
         idCardProbe?.cancel()
         idCardProbe = nil
         restoreIdCardBrightness()
+        if !isWebBottomSheetOpen {
+            homeHolder?.webView.allowsBackForwardNavigationGestures = true
+        }
     }
 
     private func captureIdCardBrightness() {
@@ -973,13 +983,17 @@ final class HomeBridgeHostAdapter: HomeBridgeHost {
     }
 
     func openWebViewBottomSheet() {
-        Task { @MainActor in coordinator?.isWebBottomSheetOpen = true }
+        Task { @MainActor in
+            coordinator?.isWebBottomSheetOpen = true
+            coordinator?.homeHolder?.webView.allowsBackForwardNavigationGestures = false
+        }
     }
 
     func closeWebViewBottomSheet() {
         Task { @MainActor in
             coordinator?.endIdCardModalIfNeeded()
             coordinator?.isWebBottomSheetOpen = false
+            coordinator?.homeHolder?.webView.allowsBackForwardNavigationGestures = true
         }
     }
 

--- a/iosApp/iosApp/Features/Home/HomeRootView.swift
+++ b/iosApp/iosApp/Features/Home/HomeRootView.swift
@@ -25,6 +25,7 @@ struct HomeRootView: View {
                     pushedScreen(destination)
                 }
         }
+        .interactivePopGesture()
         .preferredColorScheme(coordinator.colorScheme)
         .tint(KlasTheme.primary)
         .onAppear {

--- a/iosApp/iosApp/Features/Home/HomeView.swift
+++ b/iosApp/iosApp/Features/Home/HomeView.swift
@@ -37,6 +37,9 @@ struct HomeView: View {
             coordinator.handleHomeNavigation(state)
         }
         .webDownloadOverlay(holder)
+        .onDisappear {
+            coordinator.endIdCardModalIfNeeded()
+        }
         .accessibilityIdentifier("home_view")
     }
 }

--- a/iosApp/iosApp/Features/Lecture/LectureView.swift
+++ b/iosApp/iosApp/Features/Lecture/LectureView.swift
@@ -218,6 +218,14 @@ final class LectureScreenModel: ObservableObject {
         message.contains(bootstrapLectureErrorMarker)
     }
 
+    var consumesNativeBack: Bool {
+        Self.consumesNativeBack(showingKlas: showingKlas, klasCanGoBack: klasHolder.navigationState.canGoBack)
+    }
+
+    nonisolated static func consumesNativeBack(showingKlas: Bool, klasCanGoBack: Bool) -> Bool {
+        showingKlas && !klasCanGoBack
+    }
+
     func handleBack(dismiss: () -> Void) {
         if showingKlas {
             if !klasHolder.goBack() {
@@ -422,6 +430,10 @@ struct LectureView: View {
             model.handleKlasNavigation(state)
         }
         .accessibilityIdentifier("lecture_view")
+        .interactivePopGesture(
+            consumesNativeBack: model.consumesNativeBack,
+            onConsumeBack: { model.handleBack(dismiss: { dismiss() }) }
+        )
     }
 
     private var hidesWebForOverlay: Bool {

--- a/iosApp/iosApp/Features/Link/LinkView.swift
+++ b/iosApp/iosApp/Features/Link/LinkView.swift
@@ -7,7 +7,9 @@ final class LinkScreenModel: ObservableObject {
     let sessionToken: SecretValue?
     weak var coordinator: HomeCoordinator?
     private var host: LinkHostAdapter
-    var isWebBottomSheetOpen = false
+    @Published var isWebBottomSheetOpen = false
+
+    var consumesNativeBack: Bool { isWebBottomSheetOpen }
 
     init(url: String, sessionToken: SecretValue?, coordinator: HomeCoordinator) {
         self.sessionToken = sessionToken
@@ -79,7 +81,10 @@ struct LinkView: View {
     }
 
     var body: some View {
-        PushedWebStack(holder: model.holder) {
+        PushedWebStack(
+            holder: model.holder,
+            consumesNativeBack: model.consumesNativeBack
+        ) {
             model.handleBack(dismiss: { dismiss() })
         }
         .accessibilityIdentifier("link_view")

--- a/iosApp/iosApp/Features/Video/VideoView.swift
+++ b/iosApp/iosApp/Features/Video/VideoView.swift
@@ -387,6 +387,10 @@ final class VideoScreenModel: ObservableObject {
         }
     }
 
+    var consumesNativeBack: Bool {
+        isPlayerVisible || showingKlas
+    }
+
     func handleBack(dismiss: () -> Void) {
         if isInPictureInPicture {
             if isPlayerVisible || showingKlas {
@@ -663,6 +667,10 @@ struct VideoView: View {
         .webJavaScriptAlert(model.videoHolder, enabled: model.isPlayerVisible)
         .webDownloadOverlay(model.listHolder)
         .webDownloadOverlay(model.klasHolder)
+        .interactivePopGesture(
+            consumesNativeBack: model.consumesNativeBack,
+            onConsumeBack: { model.handleBack(dismiss: { dismiss() }) }
+        )
         .onAppear {
             model.videoHolder.webView.alpha = 1
             model.start()

--- a/iosApp/iosApp/Platform/IosInteractivePopGesture.swift
+++ b/iosApp/iosApp/Platform/IosInteractivePopGesture.swift
@@ -1,0 +1,253 @@
+import SwiftUI
+import UIKit
+import WebKit
+
+enum InteractivePopDecision: Equatable {
+    case ignore
+    case consumeNativeBack
+    case yieldToWebHistory
+    case beginSystemPop
+}
+
+struct InteractivePopPolicy: Equatable {
+    var isPushed: Bool
+    var consumesNativeBack: Bool
+    var activeWebViewCanGoBack: Bool
+
+    var decision: InteractivePopDecision {
+        guard isPushed else { return .ignore }
+        if consumesNativeBack { return .consumeNativeBack }
+        if activeWebViewCanGoBack { return .yieldToWebHistory }
+        return .beginSystemPop
+    }
+
+    static func shouldCommitNativeBack(translationX: CGFloat, velocityX: CGFloat) -> Bool {
+        translationX > 80 || velocityX > 500
+    }
+}
+
+struct InteractivePopGestureInstaller: UIViewControllerRepresentable {
+    var consumesNativeBack: Bool = false
+    var onConsumeBack: (() -> Void)?
+
+    func makeUIViewController(context: Context) -> Controller {
+        let controller = Controller()
+        controller.consumesNativeBack = consumesNativeBack
+        controller.onConsumeBack = onConsumeBack
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: Controller, context: Context) {
+        uiViewController.consumesNativeBack = consumesNativeBack
+        uiViewController.onConsumeBack = onConsumeBack
+        uiViewController.configureNav()
+    }
+
+    final class Controller: UIViewController {
+        var consumesNativeBack = false
+        var onConsumeBack: (() -> Void)?
+
+        override func didMove(toParent parent: UIViewController?) {
+            super.didMove(toParent: parent)
+            configureNav()
+        }
+
+        override func viewDidAppear(_ animated: Bool) {
+            super.viewDidAppear(animated)
+            configureNav()
+        }
+
+        override func viewDidLayoutSubviews() {
+            super.viewDidLayoutSubviews()
+            configureNav()
+        }
+
+        func configureNav() {
+            guard let nav = findNav() else { return }
+            nav.interactivePopGestureRecognizer?.isEnabled = true
+            nav.interactivePopGestureRecognizer?.delegate = nav
+            nav.installConsumeBackRecognizerIfNeeded()
+            guard nav.topInteractivePopInstaller() === self else { return }
+            nav.applyWebHistoryGestures(enabled: !consumesNativeBack)
+        }
+
+        private func findNav() -> UINavigationController? {
+            if let nav = navigationController ?? parent?.navigationController {
+                return nav
+            }
+            if let root = view.window?.rootViewController ?? parent {
+                if let found = search(root) { return found }
+            }
+            if let targetView = view.window ?? parent?.view {
+                if let found = search(targetView) { return found }
+            }
+            return nil
+        }
+
+        private func search(_ vc: UIViewController) -> UINavigationController? {
+            if let nav = vc as? UINavigationController { return nav }
+            for child in vc.children {
+                if let found = search(child) { return found }
+            }
+            return nil
+        }
+
+        private func search(_ view: UIView) -> UINavigationController? {
+            var responder: UIResponder? = view
+            while let r = responder {
+                if let nav = r as? UINavigationController { return nav }
+                responder = r.next
+            }
+            for subview in view.subviews {
+                if let found = search(subview) { return found }
+            }
+            return nil
+        }
+    }
+}
+
+extension View {
+    func interactivePopGesture(
+        consumesNativeBack: Bool = false,
+        onConsumeBack: (() -> Void)? = nil
+    ) -> some View {
+        background(
+            InteractivePopGestureInstaller(
+                consumesNativeBack: consumesNativeBack,
+                onConsumeBack: onConsumeBack
+            )
+        )
+    }
+}
+
+private enum InteractivePopAssociated {
+    static var consumeController: UInt8 = 0
+}
+
+private final class InteractivePopConsumeController: NSObject {
+    let recognizer: UIScreenEdgePanGestureRecognizer
+    weak var navigationController: UINavigationController?
+
+    init(navigationController: UINavigationController) {
+        self.recognizer = UIScreenEdgePanGestureRecognizer()
+        self.navigationController = navigationController
+        super.init()
+        recognizer.edges = .left
+        recognizer.delegate = navigationController
+        recognizer.addTarget(self, action: #selector(handle(_:)))
+        navigationController.view.addGestureRecognizer(recognizer)
+    }
+
+    @objc func handle(_ gesture: UIScreenEdgePanGestureRecognizer) {
+        guard gesture.state == .ended else { return }
+        let view = gesture.view
+        navigationController?.commitConsumeBackIfNeeded(
+            translationX: gesture.translation(in: view).x,
+            velocityX: gesture.velocity(in: view).x
+        )
+    }
+}
+
+extension UINavigationController: @retroactive UIGestureRecognizerDelegate {
+    var consumeBackRecognizer: UIScreenEdgePanGestureRecognizer? {
+        consumeController?.recognizer
+    }
+
+    func installConsumeBackRecognizerIfNeeded() {
+        guard consumeController == nil else { return }
+        consumeController = InteractivePopConsumeController(navigationController: self)
+    }
+
+    func commitConsumeBackIfNeeded(translationX: CGFloat, velocityX: CGFloat) {
+        guard InteractivePopPolicy.shouldCommitNativeBack(translationX: translationX, velocityX: velocityX) else {
+            return
+        }
+        topInteractivePopInstaller()?.onConsumeBack?()
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        let decision = popDecision(for: gestureRecognizer)
+        if gestureRecognizer === consumeBackRecognizer {
+            return decision == .consumeNativeBack
+        }
+        guard gestureRecognizer === interactivePopGestureRecognizer else { return true }
+        return decision == .beginSystemPop
+    }
+
+    func popDecision(for gestureRecognizer: UIGestureRecognizer) -> InteractivePopDecision {
+        let location = gestureRecognizer.location(in: view)
+        return InteractivePopPolicy(
+            isPushed: viewControllers.count > 1,
+            consumesNativeBack: topInteractivePopInstaller()?.consumesNativeBack ?? false,
+            activeWebViewCanGoBack: activeWebView(at: location)?.canGoBack ?? false
+        ).decision
+    }
+
+    func topInteractivePopInstaller() -> InteractivePopGestureInstaller.Controller? {
+        guard let top = topViewController else { return nil }
+        return innermostInstaller(in: top)
+    }
+
+    func applyWebHistoryGestures(enabled: Bool) {
+        topViewController?.view.forEachDescendant(ofType: WKWebView.self) { webView in
+            webView.allowsBackForwardNavigationGestures = enabled
+        }
+    }
+
+    func activeWebView(at location: CGPoint) -> WKWebView? {
+        guard let topView = topViewController?.view else { return nil }
+        let pointInTopView = view.convert(location, to: topView)
+        guard let hitView = topView.hitTest(pointInTopView, with: nil) else { return nil }
+        return hitView.findAncestor(ofType: WKWebView.self)
+    }
+
+    private var consumeController: InteractivePopConsumeController? {
+        get {
+            objc_getAssociatedObject(self, &InteractivePopAssociated.consumeController) as? InteractivePopConsumeController
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &InteractivePopAssociated.consumeController,
+                newValue,
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
+    private func innermostInstaller(in viewController: UIViewController) -> InteractivePopGestureInstaller.Controller? {
+        var deepest: (controller: InteractivePopGestureInstaller.Controller, depth: Int)?
+        func walk(_ viewController: UIViewController, depth: Int) {
+            if let controller = viewController as? InteractivePopGestureInstaller.Controller {
+                if deepest == nil || depth >= deepest!.depth {
+                    deepest = (controller, depth)
+                }
+            }
+            for child in viewController.children {
+                walk(child, depth: depth + 1)
+            }
+        }
+        walk(viewController, depth: 0)
+        return deepest?.controller
+    }
+}
+
+extension UIView {
+    func findAncestor<T: UIView>(ofType type: T.Type) -> T? {
+        var current: UIView? = self
+        while let view = current {
+            if let target = view as? T { return target }
+            current = view.superview
+        }
+        return nil
+    }
+
+    func forEachDescendant<T: UIView>(ofType type: T.Type, _ body: (T) -> Void) {
+        if let match = self as? T {
+            body(match)
+        }
+        for subview in subviews {
+            subview.forEachDescendant(ofType: type, body)
+        }
+    }
+}

--- a/iosApp/iosApp/WebView/PushedWebStack.swift
+++ b/iosApp/iosApp/WebView/PushedWebStack.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct PushedWebStack: View {
     @ObservedObject var holder: WebViewHolder
     var showsPageLoading: Bool = true
+    var consumesNativeBack: Bool = false
     var onBack: () -> Void
 
     var body: some View {
@@ -43,6 +44,10 @@ struct PushedWebStack: View {
         }
         .webJavaScriptAlert(holder)
         .webDownloadOverlay(holder)
+        .interactivePopGesture(
+            consumesNativeBack: consumesNativeBack,
+            onConsumeBack: onBack
+        )
     }
 
     private var showsPageLoadingOverlay: Bool {

--- a/iosApp/iosApp/WebView/WebViewHolder.swift
+++ b/iosApp/iosApp/WebView/WebViewHolder.swift
@@ -96,6 +96,7 @@ final class WebViewHolder: NSObject, ObservableObject {
         let created = WKWebView(frame: .zero, configuration: configuration)
         created.navigationDelegate = navigationRelay
         created.uiDelegate = uiRelay
+        created.allowsBackForwardNavigationGestures = true
         Self.configureWebScrollView(created.scrollView)
         _webView = created
         return created

--- a/iosApp/iosAppTests/InteractivePopGesturePolicyTests.swift
+++ b/iosApp/iosAppTests/InteractivePopGesturePolicyTests.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+import UIKit
+import WebKit
+import XCTest
+@testable import kw_klas_plus
+
+@MainActor
+final class InteractivePopGesturePolicyTests: XCTestCase {
+    private final class MockWebView: WKWebView {
+        var mockCanGoBack: Bool = false
+        override var canGoBack: Bool { mockCanGoBack }
+    }
+
+    private func makeNavigationController(root: UIViewController) -> UINavigationController {
+        let nav = UINavigationController(rootViewController: root)
+        nav.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+        nav.interactivePopGestureRecognizer?.delegate = nav
+        return nav
+    }
+
+    func testPolicyIgnoresRootEvenWithNativeLayer() {
+        let policy = InteractivePopPolicy(
+            isPushed: false,
+            consumesNativeBack: true,
+            activeWebViewCanGoBack: true
+        )
+        XCTAssertEqual(policy.decision, .ignore)
+    }
+
+    func testPolicyPrefersNativeLayerOverWebHistory() {
+        let policy = InteractivePopPolicy(
+            isPushed: true,
+            consumesNativeBack: true,
+            activeWebViewCanGoBack: true
+        )
+        XCTAssertEqual(policy.decision, .consumeNativeBack)
+    }
+
+    func testPolicyYieldsToWebHistoryWhenNoNativeLayer() {
+        let policy = InteractivePopPolicy(
+            isPushed: true,
+            consumesNativeBack: false,
+            activeWebViewCanGoBack: true
+        )
+        XCTAssertEqual(policy.decision, .yieldToWebHistory)
+    }
+
+    func testPolicyBeginsSystemPopWhenPushedWithoutLayerOrHistory() {
+        let policy = InteractivePopPolicy(
+            isPushed: true,
+            consumesNativeBack: false,
+            activeWebViewCanGoBack: false
+        )
+        XCTAssertEqual(policy.decision, .beginSystemPop)
+    }
+
+    func testNativeBackCommitUsesTranslationOrVelocityThreshold() {
+        XCTAssertTrue(InteractivePopPolicy.shouldCommitNativeBack(translationX: 81, velocityX: 0))
+        XCTAssertTrue(InteractivePopPolicy.shouldCommitNativeBack(translationX: 10, velocityX: 501))
+        XCTAssertFalse(InteractivePopPolicy.shouldCommitNativeBack(translationX: 80, velocityX: 500))
+    }
+
+    func testLectureConsumesNativeBackOnlyWhenKlasOverlayHasNoHistory() {
+        XCTAssertTrue(LectureScreenModel.consumesNativeBack(showingKlas: true, klasCanGoBack: false))
+        XCTAssertFalse(LectureScreenModel.consumesNativeBack(showingKlas: true, klasCanGoBack: true))
+        XCTAssertFalse(LectureScreenModel.consumesNativeBack(showingKlas: false, klasCanGoBack: false))
+    }
+
+    func testRootViewControllerDoesNotBeginGesture() {
+        let nav = makeNavigationController(root: UIViewController())
+        nav.view.layoutIfNeeded()
+
+        guard let gesture = nav.interactivePopGestureRecognizer else {
+            XCTFail("interactivePopGestureRecognizer must exist")
+            return
+        }
+
+        XCTAssertFalse(nav.gestureRecognizerShouldBegin(gesture))
+    }
+
+    func testPushedNativeViewBeginsGesture() {
+        let root = UIViewController()
+        let pushed = UIViewController()
+        pushed.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+        let nav = makeNavigationController(root: root)
+        nav.pushViewController(pushed, animated: false)
+        nav.view.layoutIfNeeded()
+
+        guard let gesture = nav.interactivePopGestureRecognizer else {
+            XCTFail("interactivePopGestureRecognizer must exist")
+            return
+        }
+
+        XCTAssertTrue(nav.gestureRecognizerShouldBegin(gesture))
+    }
+
+    func testPushedViewWithWebViewCannotGoBackBeginsGesture() {
+        let root = UIViewController()
+        let pushed = UIViewController()
+        pushed.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+        let webView = MockWebView(frame: pushed.view.bounds, configuration: WKWebViewConfiguration())
+        webView.mockCanGoBack = false
+        pushed.view.addSubview(webView)
+
+        let nav = makeNavigationController(root: root)
+        nav.pushViewController(pushed, animated: false)
+        nav.view.layoutIfNeeded()
+
+        guard let gesture = nav.interactivePopGestureRecognizer else {
+            XCTFail("interactivePopGestureRecognizer must exist")
+            return
+        }
+
+        XCTAssertTrue(nav.gestureRecognizerShouldBegin(gesture))
+    }
+
+    func testPushedViewWithWebViewCanGoBackYieldsGesture() {
+        let root = UIViewController()
+        let pushed = UIViewController()
+        pushed.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+        let webView = MockWebView(frame: pushed.view.bounds, configuration: WKWebViewConfiguration())
+        webView.mockCanGoBack = true
+        pushed.view.addSubview(webView)
+
+        let nav = makeNavigationController(root: root)
+        nav.pushViewController(pushed, animated: false)
+        nav.view.layoutIfNeeded()
+
+        guard let gesture = nav.interactivePopGestureRecognizer else {
+            XCTFail("interactivePopGestureRecognizer must exist")
+            return
+        }
+
+        XCTAssertFalse(nav.gestureRecognizerShouldBegin(gesture))
+    }
+
+    func testStackedWebViewsResolvesTopmostActiveWebView() {
+        let root = UIViewController()
+        let pushed = UIViewController()
+        pushed.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+        let bottomWebView = MockWebView(frame: pushed.view.bounds, configuration: WKWebViewConfiguration())
+        bottomWebView.mockCanGoBack = true
+
+        let topWebView = MockWebView(frame: pushed.view.bounds, configuration: WKWebViewConfiguration())
+        topWebView.mockCanGoBack = false
+        topWebView.alpha = 0
+        topWebView.isUserInteractionEnabled = false
+
+        pushed.view.addSubview(bottomWebView)
+        pushed.view.addSubview(topWebView)
+
+        let nav = makeNavigationController(root: root)
+        nav.pushViewController(pushed, animated: false)
+        nav.view.layoutIfNeeded()
+
+        guard let gesture = nav.interactivePopGestureRecognizer else {
+            XCTFail("interactivePopGestureRecognizer must exist")
+            return
+        }
+
+        // topWebView is hidden & non-interactive -> bottomWebView is active and canGoBack -> yields
+        XCTAssertFalse(nav.gestureRecognizerShouldBegin(gesture))
+
+        // Now activate topWebView
+        topWebView.alpha = 1
+        topWebView.isUserInteractionEnabled = true
+
+        // topWebView is now active and cannot go back -> pop allowed
+        XCTAssertTrue(nav.gestureRecognizerShouldBegin(gesture))
+    }
+
+    func testNativeLayerBlocksSystemPopEvenWhenWebCanGoBack() {
+        let root = UIViewController()
+        let pushed = UIViewController()
+        pushed.view.frame = CGRect(x: 0, y: 0, width: 390, height: 844)
+
+        let webView = MockWebView(frame: pushed.view.bounds, configuration: WKWebViewConfiguration())
+        webView.mockCanGoBack = true
+        webView.allowsBackForwardNavigationGestures = true
+        pushed.view.addSubview(webView)
+
+        let installer = InteractivePopGestureInstaller.Controller()
+        installer.consumesNativeBack = true
+        var consumed = 0
+        installer.onConsumeBack = { consumed += 1 }
+        pushed.addChild(installer)
+        installer.didMove(toParent: pushed)
+
+        let nav = makeNavigationController(root: root)
+        nav.pushViewController(pushed, animated: false)
+        nav.view.layoutIfNeeded()
+        installer.configureNav()
+
+        guard let popGesture = nav.interactivePopGestureRecognizer else {
+            XCTFail("interactivePopGestureRecognizer must exist")
+            return
+        }
+        guard let consumeGesture = nav.consumeBackRecognizer else {
+            XCTFail("consumeBackRecognizer must exist")
+            return
+        }
+
+        XCTAssertFalse(nav.gestureRecognizerShouldBegin(popGesture))
+        XCTAssertTrue(nav.gestureRecognizerShouldBegin(consumeGesture))
+        XCTAssertFalse(webView.allowsBackForwardNavigationGestures)
+
+        nav.commitConsumeBackIfNeeded(translationX: 10, velocityX: 0)
+        XCTAssertEqual(consumed, 0)
+
+        nav.commitConsumeBackIfNeeded(translationX: 100, velocityX: 0)
+        XCTAssertEqual(consumed, 1)
+
+        installer.consumesNativeBack = false
+        installer.configureNav()
+        XCTAssertFalse(nav.gestureRecognizerShouldBegin(popGesture))
+        XCTAssertFalse(nav.gestureRecognizerShouldBegin(consumeGesture))
+        XCTAssertTrue(webView.allowsBackForwardNavigationGestures)
+
+        webView.mockCanGoBack = false
+        XCTAssertTrue(nav.gestureRecognizerShouldBegin(popGesture))
+        XCTAssertFalse(nav.gestureRecognizerShouldBegin(consumeGesture))
+    }
+
+    func testInstallerConfiguresNavigationControllerDelegate() {
+        let root = UIViewController()
+        let nav = UINavigationController(rootViewController: root)
+        let controller = InteractivePopGestureInstaller.Controller()
+
+        root.addChild(controller)
+        controller.didMove(toParent: root)
+
+        XCTAssertTrue(nav.interactivePopGestureRecognizer?.delegate === nav)
+    }
+
+    func testSwiftUINavigationStackIntegration() {
+        struct TestHost: View {
+            @State var path = [1]
+            var body: some View {
+                NavigationStack(path: $path) {
+                    Text("Home")
+                        .navigationDestination(for: Int.self) { _ in
+                            Text("Detail")
+                        }
+                }
+                .interactivePopGesture()
+            }
+        }
+
+        let host = UIHostingController(rootView: TestHost())
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        window.rootViewController = host
+        window.makeKeyAndVisible()
+        host.view.layoutIfNeeded()
+
+        func findNavController(in view: UIView) -> UINavigationController? {
+            var responder: UIResponder? = view
+            while let r = responder {
+                if let nav = r as? UINavigationController { return nav }
+                responder = r.next
+            }
+            for subview in view.subviews {
+                if let found = findNavController(in: subview) { return found }
+            }
+            return nil
+        }
+
+        let nav = findNavController(in: host.view)
+        print("FOUND NAV: \(String(describing: nav))")
+        print("DELEGATE: \(String(describing: nav?.interactivePopGestureRecognizer?.delegate))")
+        XCTAssertNotNil(nav)
+        XCTAssertTrue(nav?.interactivePopGestureRecognizer?.delegate === nav)
+    }
+}

--- a/iosApp/iosAppTests/IosHomeHostTests.swift
+++ b/iosApp/iosAppTests/IosHomeHostTests.swift
@@ -202,6 +202,28 @@ final class IosHomeHostTests: XCTestCase {
     }
 
     @MainActor
+    func testLectureConsumesNativeBackWhenKlasOverlayHasNoHistory() {
+        let coordinator = makeHomeCoordinator()
+        defer { coordinator.dispose() }
+        let model = LectureScreenModel(
+            subjectId: "TEST001",
+            subjectName: "테스트강의",
+            yearSemester: "2026,1",
+            sessionToken: SecretValue.companion.of(value: "session"),
+            coordinator: coordinator
+        )
+        defer {
+            model.uiHolder.dispose()
+            model.klasHolder.dispose()
+        }
+
+        XCTAssertFalse(model.consumesNativeBack)
+        model.showingKlas = true
+        XCTAssertTrue(model.consumesNativeBack)
+        XCTAssertFalse(model.klasHolder.navigationState.canGoBack)
+    }
+
+    @MainActor
     func testOpenLectureWindowExpiryEndsSuppressionWithoutSecondCall() {
         let coordinator = makeHomeCoordinator()
         defer { coordinator.dispose() }
@@ -512,6 +534,32 @@ final class IosHomeHostTests: XCTestCase {
         XCTAssertTrue(
             KlasWebAutomationScripts.shared.closeBottomSheet().reveal().contains("window.closeWebViewBottomSheet")
         )
+    }
+
+    @MainActor
+    func testIdCardModalDisablesBackForwardGesturesAndRestoresOnDismiss() {
+        let suite = "com.icecream.kwklasplus.test.home.modal.gestures.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let runtime = IosAuthRuntime.companion.create(defaults: defaults)
+        let coordinator = HomeCoordinator(authRuntime: runtime, onLogout: {})
+
+        coordinator.handleBootstrap(Self.readyHomeResult())
+
+        guard let homeHolder = coordinator.homeHolder else {
+            XCTFail("homeHolder must be attached")
+            return
+        }
+
+        XCTAssertTrue(homeHolder.webView.allowsBackForwardNavigationGestures)
+
+        coordinator.requestIdCardQRValue()
+        XCTAssertFalse(homeHolder.webView.allowsBackForwardNavigationGestures)
+
+        coordinator.endIdCardModalIfNeeded()
+        XCTAssertTrue(homeHolder.webView.allowsBackForwardNavigationGestures)
     }
 
     @MainActor

--- a/iosApp/iosAppTests/IosVideoHostTests.swift
+++ b/iosApp/iosAppTests/IosVideoHostTests.swift
@@ -379,6 +379,28 @@ final class IosVideoHostTests: XCTestCase {
         XCTAssertTrue(dismissed)
     }
 
+    func testConsumesNativeBackWhilePlayerOrKlasOverlayIsVisible() {
+        let coordinator = makeCoordinator()
+        defer { coordinator.dispose() }
+        coordinator.handleBootstrap(Self.readyHomeResult())
+        let model = VideoScreenModel(
+            subjectId: "SUBJ01",
+            yearSemester: "2026,1",
+            sessionToken: coordinator.sessionToken,
+            coordinator: coordinator
+        )
+        XCTAssertFalse(model.consumesNativeBack)
+
+        model.receiveVideoURL("https://vod.kw.ac.kr/player")
+        XCTAssertTrue(model.consumesNativeBack)
+
+        model.handleBack(dismiss: {})
+        XCTAssertFalse(model.consumesNativeBack)
+
+        model.showingKlas = true
+        XCTAssertTrue(model.consumesNativeBack)
+    }
+
     func testConfirmCloseResetsStateAndHidesPlayer() {
         let coordinator = makeCoordinator()
         defer { coordinator.dispose() }


### PR DESCRIPTION
## Summary

SwiftUI NavigationStack에서 커스텀 네비게이션 바/뒤로가기 버튼(.navigationBarBackButtonHidden(true))을 쓰면 시스템 Interactive Pop Gesture가 꺼집니다. 이를 복원하고, WKWebView 히스토리·네이티브 오버레이와 충돌하지 않도록 스마트 백 제스처를 넣었습니다.

제스처 시작 시 우선순위는 다음과 같습니다.

1. 루트 화면 → 무시
2. 플레이어, KLAS 오버레이, 바텀시트처럼 화면 위에 네이티브 UI가 있으면, 화면을 통째로 빼지 않고 커스텀 뒤로가기와 같이 그 레이어만 닫음
3. 터치한 WKWebView에 웹 히스토리가 있으면 페이지 뒤로가기
4. 그 외에는 이전 화면으로 pop

네이티브 오버레이가 뒤로가기를 처리할 때는 웹뷰 자체의 스와이프 백을 끄고, 화면 왼쪽 끝에서 충분히 밀었을 때만 오버레이를 닫습니다. 웹뷰가 겹쳐 있으면 실제로 터치한 쪽의 히스토리만 봅니다.

## 화면별 동작

- Home: NavigationStack에 제스처를 연결. 모바일 학생증·웹 바텀시트가 열려 있으면 웹 스와이프 백을 막고, 다른 화면으로 가거나 Home이 사라질 때 학생증을 닫고 밝기를 되돌림
- Lecture: KLAS 오버레이가 열려 있고 그 안에 히스토리가 없으면 오버레이만 닫음. 히스토리가 있으면 웹 뒤로가기
- Video: 플레이어나 KLAS 오버레이가 보이면 Video 화면 전체를 빼지 않고 강의 목록으로 돌아감
- Link / PushedWebStack: 웹 바텀시트가 열려 있으면 시트만 닫음. 일반 푸시 웹 화면은 웹 히스토리 → 없으면 이전 화면으로 pop

## Test Plan

- [x] 홈에서는 왼쪽 스와이프해도 화면이 빠지지 않는지
- [x] 공지/링크 등 푸시 웹 화면: 히스토리가 있으면 페이지 뒤로, 없으면 화면 pop
- [x] 강의: KLAS 오버레이에서 스와이프 시 오버레이만 닫히는지, 오버레이 안 히스토리가 있으면 웹 뒤로만 가는지
- [x] 동영상: 플레이어/인증 오버레이 중 스와이프해도 Video 화면 전체가 빠지지 않는지
- [x] 모바일 학생증·웹 바텀시트 중 웹 스와이프 백이 막히고, 닫힌 뒤 다시 켜지는지.
- [x] 겹친 WebView(강의 UI / KLAS)에서 보이는 쪽 히스토리만 반영되는지
